### PR TITLE
Make the date generated optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,10 +138,16 @@
 			fs.writeFileSync('results.json', json, 'utf8');
 		}
 
+		let dateGenerated = true;
+		if (cliArgs['date-generated'] === false) {
+			// in the case of undefined the default should be true
+			dateGenerated = false
+		}
 		console.log('Writing summary files...');
 		fs.writeFileSync('developer.md', templates.developer({messages, fns: templateFunctions}).replace(/\n\t+/g, '\n'));
 		console.log('> Developer index done');
-		fs.writeFileSync('issues.md', templates.issues({messages, jobURL, fns: templateFunctions}).replace(/\n\t+/g, '\n'));
+		fs.writeFileSync('issues.md', templates.issues({
+			messages, jobURL, dateGenerated: dateGenerated, fns: templateFunctions}).replace(/\n\t+/g, '\n'));
 		console.log('> Issue summary done');
 
 		console.log('> Summary files done!');

--- a/templates/issues.jst
+++ b/templates/issues.jst
@@ -23,7 +23,7 @@ title: {{?issues && issues.summaries.count}}Issues - {{=issues.summaries.errors|
 navigation: true
 ---
 <p style="text-align:right;color:#cccs">
-	Generated {{=(new Date()).toUTCString()}}
+	{{?ctx.dateGenerated}}Generated {{=(new Date()).toUTCString()}}{{?}}
 	{{?ctx.jobURL}}<br><a href="{{=ctx.jobURL}}">Build Log</a>{{?}}
 </p>
 {{?lamsMessages.length}}


### PR DESCRIPTION
The problem I was having when I put LAMS into our CI system is that the issues.md was ALWAYS
marked as changed and that was because of the "Generated YYYY-MM-DD HH:MM:SS" string.

So this makes it optional, by specifying `--no-date-generated`