### PR TITLE
ensure settings dir exists

### DIFF
--- a/lib/tracking.js
+++ b/lib/tracking.js
@@ -27,7 +27,8 @@ exports = module.exports = function({
 	let digestMismatch;
 	{/* Process prefs */
 		let userEmailOrHash; let saveReporting;
-		const settingsPath = path.resolve(os.homedir(), '.look-at-me-sideways/settings.json');
+		const settingsDir = path.resolve(os.homedir(), '.look-at-me-sideways');
+		const settingsPath = path.join(settingsDir, 'settings.json');
 		const settings = (()=>{
 			try {
 				let str = fs.readFileSync(settingsPath);
@@ -73,6 +74,15 @@ exports = module.exports = function({
 					? {enabled, userHash, licenseKey, privacyDigest, timestamp: prefTimestamp}
 					: settings.reporting,
 			};
+			try {
+				fs.mkdirSync(settingsDir);
+			} catch (e) {
+				if (e.code === 'EEXIST') {
+					// already exists, OK
+				} else {
+					throw e;
+				}
+			}
 			fs.writeFileSync(settingsPath, JSON.stringify(updatedSettings));
 		} catch (e) {
 			// Do nothing


### PR DESCRIPTION
Currently, if you don't have the `~/.look-at-me-sideways` it doesn't write any settings. This PR just attempts to create that directory if you don't have it already.