### PR TITLE
Allowed files in subdirectories

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@
 				warn: (msg) => lamsMessages.push({message: msg&&msg.message||msg, level: 'lams-warning'}), // LAMS warnings should not abort the deploy
 				error: (msg) => lamsMessages.push({message: msg&&msg.message||msg, level: 'lams-error'}), // LAMS errors should abort the deploy
 			},
+			globOptions: {
+				matchBase: true
+			}
 		});
 		if (project.errors) {
 			console.log(project.errors);


### PR DESCRIPTION
Looker 6.16 allows subdirectories.  LAMS currently only searches the current directory but by passing
```
			globOptions: {
				matchBase: true
			}
```
to `parseFiles`, the parser includes subfolders.