### PR TITLE
Fixes #15

### DIFF
--- a/lib/tracking.js
+++ b/lib/tracking.js
@@ -31,7 +31,7 @@ exports = module.exports = function({
 		const settingsPath = path.join(settingsDir, 'settings.json');
 		const settings = (()=>{
 			try {
-				let str = fs.readFileSync(settingsPath);
+				let str = fs.readFileSync(settingsPath, 'utf-8');
 				return ( str.trim()[0]==='{' ? JSON.parse(str) : {} );
 			} catch (e) {
 				return {};


### PR DESCRIPTION
The settings file wasn't being encoded when it was read in, and was therefore interpreted as a buffer.