### PR TITLE
Fix for issue #43: handle multiple --- separators properly

### DIFF
--- a/__tests__/t2-10.test.js
+++ b/__tests__/t2-10.test.js
@@ -301,6 +301,33 @@ describe('Rules', () => {
 			expect(result).toContainMessage({...error, ...r.pkNamingConvention});
 		});
 
+		it('should not error if --- separator is used multiple times with leading commas', () => {
+			let result = rule(parse(`files:{} files:{
+				view: foo { derived_table: { sql:
+					WITH step_1 AS (
+						SELECT
+							account_id AS pk1_account_id
+							---
+							, COUNT(*)
+						FROM users
+						GROUP BY 1
+					),
+					step_2 AS (
+						SELECT
+							pk2_tenant_id
+							, pk2_user_id
+							---
+							, MAX(start) as last_login
+						FROM sessions
+						GROUP BY 1,2
+					)
+
+					SELECT "foo" as bar
+				;; } }
+			}`));
+			expect(result).not.toContainMessage({...error});
+		});
+
 		it('should error for each nested subquery in a transformation', () => {
 			let result = rule(parse(`files:{} files:{
 				view: foo { derived_table: { sql:

--- a/rules/t2-10.js
+++ b/rules/t2-10.js
@@ -40,7 +40,7 @@ module.exports = function(
 
 			// Initialize the "stuff to check" by removing any string literals, comments, & LookML
 			let remaining = sql
-				.replace(/\n\s*---\s*\n/, ',[sep],')
+				.replace(/\n\s*---\s*\n/g, ',[sep],')
 				.replace(new RegExp([
 					'[^\\\\\']+(\\\\.[^\\\\\']+)*\'',	// ' string literal
 					'`[^\\\\`]+(\\\\.[^\\\\`]+)*`',	// ` quoted name


### PR DESCRIPTION
This fixes issue #43 

Rule T3 erroneously fires in some cases. The root cause seems to be that the rule parser is only replacing --- once, so it misses any subsequent ones, and the `---` separator ends up getting parsed together as part of the preceding field.

Added a test to demonstrate the problem.