### PR TITLE
Enforce field rules even in refinements

### DIFF
--- a/__tests__/f1.test.js
+++ b/__tests__/f1.test.js
@@ -39,6 +39,16 @@ describe('Rules', () => {
 			expect(result).not.toContainMessage(failMessageF1);
 		});
 
+    // This may be a false negative, but it seems better than false positives
+		it('should not error for a refinement view with no table in the refined view', () => {
+			let result = rule(parse(`files:{} files:{
+				view: +foo_bar { 
+					dimension: combine { sql: \${foo.amount} + \${bar.amount} ;; } 
+				}
+			}`));
+			expect(result).not.toContainMessage(failMessageF1);
+		});
+
 		it('should not error for a field with no references', () => {
 			let result = rule(parse(`files:{} files:{
 				view: foo {
@@ -52,6 +62,16 @@ describe('Rules', () => {
 		it('should error for a base-table view with a cross-view reference', () => {
 			let result = rule(parse(`files:{} files:{
 				view: foo {
+					sql_table_name: foo ;;
+					dimension: bar { sql: \${baz.bat} ;; }
+				}
+			}`));
+			expect(result).toContainMessage(failMessageF1);
+		});
+
+		it('should error for a base-table view with a cross-view reference, even if in a refinement', () => {
+			let result = rule(parse(`files:{} files:{
+				view: +foo {
 					sql_table_name: foo ;;
 					dimension: bar { sql: \${baz.bat} ;; }
 				}

--- a/__tests__/f2.test.js
+++ b/__tests__/f2.test.js
@@ -47,6 +47,15 @@ describe('Rules', () => {
 			expect(result).toContainMessage(warnMessageF2);
 		});
 
+		it('should warn even if view_label used in a dimension within a refinement', () => {
+			let result = rule(parse(`files:{} files:{
+				view: +foo {
+					dimension: bar { view_label: "Foo2" }
+				}
+			}`));
+			expect(result).toContainMessage(warnMessageF2);
+		});
+
 		it('should warn for a measure with a view_label', () => {
 			let result = rule(parse(`files:{} files:{
 				view: foo {

--- a/__tests__/f3.test.js
+++ b/__tests__/f3.test.js
@@ -38,6 +38,15 @@ describe('Rules', () => {
 			expect(result).toContainMessage(failMessageF3);
 		});
 
+		it('should error for a measure with a type:count and no filter even within a refinement', () => {
+			let result = rule(parse(`files:{} files:{
+				view: +foo {
+					measure: bar { type: count }
+				}
+			}`));
+			expect(result).toContainMessage(failMessageF3);
+		});
+
 		it('should not error for a measure with a type:count and 1 filter', () => {
 			let result = rule(parse(`files:{} files:{
 				view: foo {

--- a/__tests__/f4.test.js
+++ b/__tests__/f4.test.js
@@ -38,6 +38,15 @@ describe('Rules', () => {
 			expect(result).toContainMessage(warnMessageF4);
 		});
 
+		it('should warn for a dimension with no description and no hidden even within a refinement', () => {
+			let result = rule(parse(` files:{} files:{
+				view: +foo {
+					dimension: bar {}
+				}
+			}`));
+			expect(result).toContainMessage(warnMessageF4);
+		});
+
 		it('should warn for a dimension with no description and hidden:no', () => {
 			let result = rule(parse(` files:{} files:{
 				view: foo {

--- a/rules/f1.js
+++ b/rules/f1.js
@@ -18,7 +18,7 @@ module.exports = function(
 	let ok = true;
 	let files = project.files || [];
 	for (let file of files) {
-		let views = Object.values(file.view || {});
+		let views = Object.values(file.view || {}).flat();
 		for (let view of views) {
 			if (!view.sql_table_name && !view.derived_table && !view.extends) {
 				continue;

--- a/rules/f2.js
+++ b/rules/f2.js
@@ -18,7 +18,7 @@ module.exports = function(
 	let ok = true;
 	let files = project.files || [];
 	for (let file of files) {
-		let views = Object.values(file.view || {});
+		let views = Object.values(file.view || {}).flat();
 		for (let view of views) {
 			let fields = []
 				.concat(Object.values(view.dimension||{}))

--- a/rules/f3.js
+++ b/rules/f3.js
@@ -18,7 +18,7 @@ module.exports = function(
 	let ok = true;
 	let files = project.files || [];
 	for (let file of files) {
-		let views = Object.values(file.view || {});
+		let views = Object.values(file.view || {}).flat();
 		for (let view of views) {
 			let fields = Object.values(view.measure || {});
 			for (let field of fields) {

--- a/rules/f4.js
+++ b/rules/f4.js
@@ -18,7 +18,7 @@ module.exports = function(
 	let ok = true;
 	let files = project.files || [];
 	for (let file of files) {
-		let views = Object.values(file.view || {});
+		let views = Object.values(file.view || {}).flat();
 		for (let view of views) {
 			let fields = []
 				.concat(Object.values(view.dimension || {}))


### PR DESCRIPTION
Hi @fabio-looker -- thanks again for accepting my fix last fall in #44 

I realized that the LAMS linter wasn't enforcing rules in refined views, so wanted to contribute a quick fix. I wasn't sure how broad to make the fix, so just kept it on the fields for now. Please let me know if you have any feedback before accepting the pull request.

I assume that since a view can have multiple refinements, the parser returns the refined views in an array like this: https://github.com/fabio-looker/node-lookml-parser/blob/master/test-projects/008-refinements/test.json -- so I just flattened the list of views returned from the parser, and it seems to work okay.