### PR TITLE
Change the primary key regex to accept pk_.*

### DIFF
--- a/__tests__/k1-2-3-4.test.js
+++ b/__tests__/k1-2-3-4.test.js
@@ -16,11 +16,33 @@ describe('Rules', () => {
 			level: 'verbose',
 		};
 
-		it('should pass if any pk is defined using [0-9]pk_.* or pk[0-9]_.*', () => {
+		it('should pass if any pk is defined using pk[0-9]_.*', () => {
 			let result = rule(parse(`files:{} files:{
 				view: foo {
 					sql_table_name: bar ;;
 					dimension: pk2_baz {}
+				}
+			}`));
+			expect(result).toContainMessage(passMessageK1);
+			expect(result).not.toContainMessage(failMessageK1);
+		});
+
+		it('should pass if any pk is defined using [0-9]pk_.*', () => {
+			let result = rule(parse(`files:{} files:{
+				view: foo {
+					sql_table_name: bar ;;
+					dimension: 2pk_baz {}
+				}
+			}`));
+			expect(result).toContainMessage(passMessageK1);
+			expect(result).not.toContainMessage(failMessageK1);
+		});
+
+		it('should pass if any pk is defined using pk_.*', () => {
+			let result = rule(parse(`files:{} files:{
+				view: foo {
+					sql_table_name: bar ;;
+					dimension: pk_baz {}
 				}
 			}`));
 			expect(result).toContainMessage(passMessageK1);
@@ -138,6 +160,28 @@ describe('Rules', () => {
 					sql_table_name: bar ;;
 					dimension: 3pk_baz {}
 					dimension: 3pk_qux {}
+				}
+			}`));
+			expect(result).toContainMessage(failMessageK2);
+		});
+
+		it('should pass if there is only one pk and it does not contain prefix or suffix', () => {
+			let result = rule(parse(`files:{} files:{
+				view: foo {
+					sql_table_name: bar ;;
+					dimension: pk_baz {}
+				}
+			}`));
+			expect(result).toContainMessage(passMessageK2);
+			expect(result).not.toContainMessage(failMessageK2);
+		});
+
+		it('should error if one key matches pk_.* and there are other keys', () => {
+			let result = rule(parse(`files:{} files:{
+				view: foo {
+					sql_table_name: bar ;;
+					dimension: pk_baz {}
+					dimension: pk2_qux {}
 				}
 			}`));
 			expect(result).toContainMessage(failMessageK2);

--- a/rules/k1-2-3-4.js
+++ b/rules/k1-2-3-4.js
@@ -22,7 +22,7 @@ module.exports = function(
 	if (allExempted) {
 		return {messages};
 	}
-	const pkNamingConvention = (d) => d.$name.match(/^([0-9]+pk|pk[0-9]+)_([a-z0-9A-Z_]+)$/);
+	const pkNamingConvention = (d) => d.$name.match(/^([0-9]+pk|pk[0-9]+|pk)_([a-z0-9A-Z_]+)$/);
 	const unique = (x, i, arr) => arr.indexOf(x) === i;
 	let files = project.files || [];
 	let matchCt = 0;
@@ -66,7 +66,6 @@ module.exports = function(
 			rule = 'K2';
 			if (!globalExemptions[rule]) {
 				let declaredNs = pkDimensions.map(pkNamingConvention).map((match) => match[1].replace('pk', '')).filter(unique);
-				// let rule = 'K2';
 				let exempt = getExemption(view, rule) || getExemption(file, rule);
 				if (declaredNs.length > 1) {
 					messages.push({
@@ -76,6 +75,7 @@ module.exports = function(
 					continue;
 				}
 				let n = parseInt(declaredNs[0]);
+				n = isNaN(n) ? 1 : n; // Handle the case of an implicit 1 (e.g. "pk_chu" instead of "pk1_chu")
 				if (n != pkDimensions.length && n !== 0) {
 					messages.push({
 						location, path, rule, exempt, level: 'error',


### PR DESCRIPTION
Following discussions on issue #67, I'm addressing issue #63.
_My experience with javascript and lookML is limited, so I can't do much more than that unfortunately :/_

This PR:
- Modifies the `pkNamingConvention` regex to also accept keys of the form `pk_.*`
- Adds tests checking that:
  - The new format is accepted
  - The implicit "1" correctly handled, i.e. accepted when there is only one pk, rejected if there are more.

The added tests do fail if the changes to `rules/k1-2-3-4.js` are not applied.

