### PR TITLE
Custom errors returning string results

### DIFF
--- a/__tests__/dummy-projects/16-custom-rule-returning-string/index.test.js
+++ b/__tests__/dummy-projects/16-custom-rule-returning-string/index.test.js
@@ -1,0 +1,56 @@
+const lams = require('../../../index.js')
+const mocks = require('../../../lib/mocks.js')
+const path= require('path')
+const options = {reporting:"no", cwd:__dirname}
+require('../../../lib/expect-to-contain-message');
+const log = x=>console.log(x)
+const testProjectName = __dirname.split(path.sep).slice(-1)[0];
+
+describe('Projects', () => {
+	describe(testProjectName, () => {
+		let {spies, process, console} = mocks()
+		let messages
+		beforeAll( async () => {
+			messages = await lams(options,{process, console})
+		})
+		it("should not error out", ()=> {
+			expect(console.error).not.toHaveBeenCalled()
+		});
+		it("it should not contain any unexpected parser (P0) errors", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "P0",
+				level: "error"
+			});
+		});
+		it("it should not contain any parser syntax (P1) errors", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "P1",
+				level: "error"
+			});
+		});
+
+		it("it should not error on rule no_abs_self_links for dimension:ok", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "no_abs_self_links",
+				level: "error",
+				location: "model:mixed/view:my_view/dimension:ok/link",
+			});
+		});
+		it("it should error on rule no_abs_self_links for dimension:bad", ()=> {
+			expect({messages}).toContainMessage({
+				rule: "no_abs_self_links",
+				level: "error",
+				location: "model:mixed/view:my_view/dimension:bad/link",
+				description: "Self-links should not be absolute. Found https://my.looker.com/dashboards/1?value={{value}}"
+			});
+		});
+		it("it should error on rule no_abs_self_links for dimension:mixed", ()=> {
+			expect({messages}).toContainMessage({
+				rule: "no_abs_self_links",
+				level: "error",
+				location: "model:mixed/view:my_view/dimension:mixed/link",
+				description: "Self-links should not be absolute. Found https://my.looker.com/dashboards/2?value={{value}}, https://my.looker.com/dashboards/3?value={{value}}"
+			});
+		});
+	});
+});

--- a/__tests__/dummy-projects/16-custom-rule-returning-string/manifest.lkml
+++ b/__tests__/dummy-projects/16-custom-rule-returning-string/manifest.lkml
@@ -1,0 +1,17 @@
+# Reuses the rule from 06-custom-rule-fields
+
+# LAMS
+# rule: no_abs_self_links {
+#	match: "$.model.*.view.*.dimension.*.link"
+#	description: "Self-links should be relative, not absolute."
+#	expr_rule: 
+#		($let links ($concat () ::match))
+#		($let urls ($map links (-> (link) ::link:url)))
+#		($let badUrls ($filter urls (-> (url) ($match "^https?://my.looker.com" url))))
+#		($if ::badUrls:length
+#			($concat "Self-links should not be absolute. Found " ($join ::badUrls ", "))
+#			true
+#		)
+#	;;
+# }
+

--- a/__tests__/dummy-projects/16-custom-rule-returning-string/mixed.model.lkml
+++ b/__tests__/dummy-projects/16-custom-rule-returning-string/mixed.model.lkml
@@ -1,0 +1,28 @@
+view: my_view {
+	dimension: bad {
+		link: {
+			label: "Bad Dashboard Link"
+			url: "https://my.looker.com/dashboards/1?value={{value}}"
+		}	
+	}
+	dimension: mixed {
+		link: {
+			label: "Ok Dashboard Link"
+			url: "/dashboards/1?value={{value}}"
+		}
+		link: {
+			label: "Bad Dashboard Link"
+			url: "https://my.looker.com/dashboards/2?value={{value}}"
+		}		
+		link: {
+			label: "Also Bad Dashboard Link"
+			url: "https://my.looker.com/dashboards/3?value={{value}}"
+		}		
+	}
+	dimension: ok {
+		link: {
+			label: "Ok (extraneous) Dashboard Link"
+			url: "https://anotherapp.com/route?value={{value}}"
+		}
+	}
+}

--- a/lib/custom-rule/custom-rule.js
+++ b/lib/custom-rule/custom-rule.js
@@ -13,11 +13,14 @@ module.exports = function getRuleMatches(
 	try {
 		const matchedNodes = getMatches(project, ruleDef)
 		const evaluatedNodes = matchedNodes.map(ruleEvaluator(ruleDef,project))
-		const messages = evaluatedNodes.map(resultInterpreter(ruleDef)).reduce(flatten,[])
+		const messages = evaluatedNodes
+			.map(resultInterpreter(ruleDef))
+			.reduce(flatten,[])
+		const exemptMessages = messages.filter(m => m.exempt)
 		const summaryMessage = {
 			'level': 'info',
 			'rule': ruleDef.$name,
-			'description': `Rule ${ruleDef.$name} was matched ${matchedNodes.length} time(s)`,
+			'description': `Rule ${ruleDef.$name} was matched ${matchedNodes.length} time(s), with ${exemptMessages.length} exemptions`,
 		};
 		return [
 			summaryMessage,

--- a/lib/custom-rule/result-interpreter.js
+++ b/lib/custom-rule/result-interpreter.js
@@ -2,14 +2,17 @@ module.exports =
 function resultInterpreter(ruleDef={}, project){
 	let ruleDefault = {
 		rule: ruleDef.$name,
+		level: "error",
 		description: ruleDef.description
 	}
 	return function interpretResult(result){
 			let resultDefault = {
 				...ruleDefault,
 				level: 'error',
-				location: formatPath(result.match.path),
-				exempt: result.exempt,
+				location: formatPath(result.match.path)
+			}
+			if (result.exempt === true) {
+				return []
 			}
 			if (result.value === true) {
 				return []
@@ -40,7 +43,6 @@ function resultInterpreter(ruleDef={}, project){
 			return [{
 				...resultDefault,
 				description: `Unsupported value returned from rule: ${(''+match.value).slice(12)}`,
-				exempt: false // Exemption within the project should not silence rule-related errors
 			}]
 		}
 	}

--- a/lib/custom-rule/rule-evaluator.js
+++ b/lib/custom-rule/rule-evaluator.js
@@ -21,9 +21,14 @@ module.exports = function ruleEvaluator(ruleDef={}, project){
 			}),
 			{modelFragment: project},
 		);
+		if(exempt){
+			return {
+				match,
+				exempt:true
+			}
+		}
 		let result = {
 			value: ruleFn(match.value, match.path, project),
-			exempt,
 			match
 		};
 		return result


### PR DESCRIPTION
Returning string values from custom rules now results in errors as originally intended and documented

Sample rule
![image](https://user-images.githubusercontent.com/23034640/164750001-8b41b498-7a1a-41c8-85ad-3c14e452addd.png)
