### PR TITLE
Tighten up exemptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ lams
 ```
 
 - **[Github Action](https://looker-open-source.github.io/look-at-me-sideways/github-action)** - This option is very quick to get started if you're using Github, and offers a compromise between convenience of setup and per-commit run performance.
-- **[Dockerized Jenkins Server](https://github.com/looker-open-source/look-at-me-sideways/blob/master/docker/README.md)** - We have provided a Docker image with an end-to-end configuration including a Jenkins server, LAMS, and Github protected branches & status checks configuration. 
+
+The following examples were prepared for v1 of LAMS, though updating them for v2 should be straightforward. Please review [v2 release notes](https://looker-open-source.github.io/look-at-me-sideways/release-notes/v2) for details. In particular, look for error messages on the console's standard output rather than a file output to be committed back to the repo. 
+
 - **[GitLab CI](https://looker-open-source.github.io/look-at-me-sideways/gitlab-ci)** - A community-contributed configuration for GitLab, which offers similarly low overhead as our dockerized Jenkins configuration
+- **[Dockerized Jenkins Server](https://github.com/looker-open-source/look-at-me-sideways/blob/master/docker/README.md)** - We have provided a Docker image with an end-to-end configuration including a Jenkins server, LAMS, and Github protected branches & status checks configuration. 
 - **[CircleCI](https://github.com/renewdotcom/renew-looker-template/blob/master/.circleci)** - A community-contributed configuration for CircleCI (external link) 
 
 ## Configuration

--- a/__tests__/docs-version-consistency.test.js
+++ b/__tests__/docs-version-consistency.test.js
@@ -5,25 +5,25 @@ const fs = require('fs');
 const packageJson = require('../package.json');
 const [major, minor, patch] = packageJson.version.split('.');
 const packageVersion = {major, minor, patch};
-const filePaths = [
-	'../README.md',
-	'../docs/github-action.md',
-	'../docs/gitlab-ci.md',
+const fileConfigs = [
+	{file: '../README.md'},
+	{file: '../docs/github-action.md'},
+	{file: '../docs/gitlab-ci.md', major: '1'}, // Expecation of `major:"1"` should be removed once the doc is updated to v2
 	// '../docker/Dockerfile' // This doc does not yet use NPM. It should first be updated to use NPM.
 ];
 
 
 describe('Docs version consistency', () => {
-	filePaths.forEach((filePath)=>{
-		it(filePath.replace('../', ''), async () => {
-			const file = await read(filePath);
+	fileConfigs.forEach((fileConfig)=>{
+		it(fileConfig.file.replace('../', ''), async () => {
+			const file = await read(fileConfig.file);
 			const commands = file.match(/npm\s*(-g)?\s*i(nstall)?\s*(-g)?\s*@looker\/look-at-me-sideways(@([0-9.]+))?/g) || [];
 			expect(commands).not.toHaveLength(0);
 			for (let command of commands) {
 				const [match, tag, version] = command.match(/look-at-me-sideways(@([0-9.]+))/) || []; // eslint-disable-line no-unused-vars
 				const [major, minor, patch] = (version||'').split('.');
 				const fileVersion = {major, minor, patch};
-				expect(fileVersion.major).toBe(packageVersion.major);
+				expect(fileVersion.major).toBe(fileConfig.major || packageVersion.major);
 			}
 		});
 	});

--- a/__tests__/dummy-projects/17-local-exemptions/f3/index.test.js
+++ b/__tests__/dummy-projects/17-local-exemptions/f3/index.test.js
@@ -1,0 +1,43 @@
+const {testName, lams, options, mocks, log} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
+ 
+describe('Projects', () => {
+	describe(testName, () => {
+		let {spies, process, console} = mocks()
+		let messages
+		beforeAll( async () => {
+			messages = await lams(options,{process, console});
+
+			log(messages.filter(m=>m.rule=="F3"))
+		})
+		it("should not error out", ()=> {
+			expect(console.error).not.toHaveBeenCalled()
+		});
+		it("it should not contain any unexpected parser (P0) errors", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "P0",
+				level: "error"
+			});
+		});
+		it("it should not contain any parser syntax (P1) errors", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "P1",
+				level: "error"
+			});
+		});
+
+		it("it should not error, because exempt, on F3 (counts must be filtered)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "F3",
+				level: "error"
+			});
+		});
+
+		it("it should provide aggregate info (1 match, 1 exempt, 0 error)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "F3",
+				level: "info",
+				description: "Evaluated 0 matches, with 1 exempt and 0 erroring"
+			});
+		});
+	});
+});

--- a/__tests__/dummy-projects/17-local-exemptions/f3/test.view.lkml
+++ b/__tests__/dummy-projects/17-local-exemptions/f3/test.view.lkml
@@ -1,0 +1,11 @@
+view: user {
+	# LAMS
+	# rule_exemptions: {
+	#	F3: "F3 is locally exempt"
+	# }
+	sql_table_name: user ;;
+
+	measure: ct {
+		type: count
+	}
+}

--- a/__tests__/dummy-projects/17-local-exemptions/k1/index.test.js
+++ b/__tests__/dummy-projects/17-local-exemptions/k1/index.test.js
@@ -1,22 +1,11 @@
-const lams = require('../../../index.js')
-const mocks = require('../../../lib/mocks.js')
-const path= require('path')
-require('../../../lib/expect-to-contain-message');
-const log = x=>console.log(x)
-const testProjectName = __dirname.split(path.sep).slice(-1)[0];
-
-
-const options = {reporting:"no", cwd:__dirname,
-	ignore: "misc{,2}/**"
-}
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
 
 describe('Projects', () => {
-	describe(testProjectName, () => {
+	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
 			messages = await lams(options,{process, console})
-			console.log(messages)
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -33,11 +22,18 @@ describe('Projects', () => {
 				level: "error"
 			});
 		});
-		it("it should check exactly one explore", ()=> {
-			expect({messages}).toContainMessage({
-				rule: "E1",
+		it("it should not error, because locally exempt, on K1 (pk naming convention used)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "K1",
+				level: "error"
+			});
+		});
+
+		it("it should provide correct aggregate info (1 match, 1 exempt, 0 error)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "F3",
 				level: "info",
-				description: "Evaluated 1 matches, with 0 exempt and 0 erroring"
+				description: "Evaluated 1 matches, with 1 exempt and 0 erroring"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/17-local-exemptions/k1/test.view.lkml
+++ b/__tests__/dummy-projects/17-local-exemptions/k1/test.view.lkml
@@ -1,0 +1,17 @@
+view: user {
+	# LAMS
+	# rule_exemptions: {
+	#	K1: "This is not implementing the primary key naming convention"
+	# }
+
+	sql_table_name: user ;;
+
+	dimension: info {
+		description: "Something about this table"
+	}
+
+	dimension: id {
+		primary_key: yes
+		# I have decided not to follow the K1 naming convention, and exempted the view from this rule
+	}
+}

--- a/__tests__/dummy-projects/17-local-exemptions/k3/index.test.js
+++ b/__tests__/dummy-projects/17-local-exemptions/k3/index.test.js
@@ -1,22 +1,11 @@
-const lams = require('../../../index.js')
-const mocks = require('../../../lib/mocks.js')
-const path= require('path')
-require('../../../lib/expect-to-contain-message');
-const log = x=>console.log(x)
-const testProjectName = __dirname.split(path.sep).slice(-1)[0];
-
-
-const options = {reporting:"no", cwd:__dirname,
-	ignore: "misc{,2}/**"
-}
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
 
 describe('Projects', () => {
-	describe(testProjectName, () => {
+	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
 			messages = await lams(options,{process, console})
-			console.log(messages)
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -33,11 +22,18 @@ describe('Projects', () => {
 				level: "error"
 			});
 		});
-		it("it should check exactly one explore", ()=> {
-			expect({messages}).toContainMessage({
-				rule: "E1",
+		it("it should not error, because locally exempt, on K3 (key dimensions first)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "K3",
+				level: "error"
+			});
+		});
+
+		it("it should provide correct aggregate info (1 match, 1 exempt, 0 error)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "F3",
 				level: "info",
-				description: "Evaluated 1 matches, with 0 exempt and 0 erroring"
+				description: "Evaluated 1 matches, with 1 exempt and 0 erroring"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/17-local-exemptions/k3/test.view.lkml
+++ b/__tests__/dummy-projects/17-local-exemptions/k3/test.view.lkml
@@ -1,0 +1,14 @@
+view: user {
+	# LAMS
+	# rule_exemptions: {
+	#	K3: "This view has non-key dimensions first, against K3, but K3 is globally exempt"
+	# }
+
+	sql_table_name: user ;;
+
+	dimension: info {
+		description: "Something about this table"
+	}
+
+	dimension: pk1_user_id {}
+}

--- a/__tests__/dummy-projects/17-local-exemptions/t2/index.test.js
+++ b/__tests__/dummy-projects/17-local-exemptions/t2/index.test.js
@@ -1,22 +1,11 @@
-const lams = require('../../../index.js')
-const mocks = require('../../../lib/mocks.js')
-const path= require('path')
-require('../../../lib/expect-to-contain-message');
-const log = x=>console.log(x)
-const testProjectName = __dirname.split(path.sep).slice(-1)[0];
-
-
-const options = {reporting:"no", cwd:__dirname,
-	ignore: "misc{,2}/**"
-}
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
 
 describe('Projects', () => {
-	describe(testProjectName, () => {
+	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
 			messages = await lams(options,{process, console})
-			console.log(messages)
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -33,11 +22,18 @@ describe('Projects', () => {
 				level: "error"
 			});
 		});
-		it("it should check exactly one explore", ()=> {
-			expect({messages}).toContainMessage({
-				rule: "E1",
+		it("it should not error, because T2 is exempt, on T8 (missing separator line)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "T8",
+				level: "error"
+			});
+		});
+
+		it("it should provide correct aggregate info (1 match, 1 exempt, 0 error)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "F3",
 				level: "info",
-				description: "Evaluated 1 matches, with 0 exempt and 0 erroring"
+				description: "Evaluated 1 matches, with 1 exempt and 0 erroring"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/17-local-exemptions/t2/test.view.lkml
+++ b/__tests__/dummy-projects/17-local-exemptions/t2/test.view.lkml
@@ -1,0 +1,17 @@
+view: user_product_affinity {
+	derived_table: {
+		# LAMS
+		# rule_exemptions: {
+		#	T2: "This DT is missing the --- separator from T8, but T2 (which introduces the requirement for T3-T10) is globally exempt"
+		# }
+
+		sql:
+			SELECT
+				pk2_user_id,
+				pk2_product_id,
+				COUNT(*) as ct
+			FROM order_items
+			GROUP BY 1,2
+		;;
+	}
+}

--- a/__tests__/dummy-projects/17-local-exemptions/t8/index.test.js
+++ b/__tests__/dummy-projects/17-local-exemptions/t8/index.test.js
@@ -1,22 +1,11 @@
-const lams = require('../../../index.js')
-const mocks = require('../../../lib/mocks.js')
-const path= require('path')
-require('../../../lib/expect-to-contain-message');
-const log = x=>console.log(x)
-const testProjectName = __dirname.split(path.sep).slice(-1)[0];
-
-
-const options = {reporting:"no", cwd:__dirname,
-	ignore: "misc{,2}/**"
-}
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
 
 describe('Projects', () => {
-	describe(testProjectName, () => {
+	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
 			messages = await lams(options,{process, console})
-			console.log(messages)
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -33,11 +22,18 @@ describe('Projects', () => {
 				level: "error"
 			});
 		});
-		it("it should check exactly one explore", ()=> {
-			expect({messages}).toContainMessage({
-				rule: "E1",
+		it("it should not error, because T8 is exempt, on T8 (missing separator line)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "T8",
+				level: "error"
+			});
+		});
+
+		it("it should provide correct aggregate info (1 match, 1 exempt, 0 error)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "F3",
 				level: "info",
-				description: "Evaluated 1 matches, with 0 exempt and 0 erroring"
+				description: "Evaluated 1 matches, with 1 exempt and 0 erroring"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/17-local-exemptions/t8/test.view.lkml
+++ b/__tests__/dummy-projects/17-local-exemptions/t8/test.view.lkml
@@ -1,0 +1,17 @@
+view: user_product_affinity {
+	derived_table: {
+		# LAMS
+		# rule_exemptions: {
+		#	T8: "This DT is missing the --- separator from T8, but T8 is locally exempt"
+		# }
+
+		sql:
+			SELECT
+				pk2_user_id,
+				pk2_product_id,
+				COUNT(*) as ct
+			FROM order_items
+			GROUP BY 1,2
+		;;
+	}
+}

--- a/__tests__/dummy-projects/18-unexempted-errors/f3/index.test.js
+++ b/__tests__/dummy-projects/18-unexempted-errors/f3/index.test.js
@@ -1,22 +1,13 @@
-const lams = require('../../../index.js')
-const mocks = require('../../../lib/mocks.js')
-const path= require('path')
-require('../../../lib/expect-to-contain-message');
-const log = x=>console.log(x)
-const testProjectName = __dirname.split(path.sep).slice(-1)[0];
-
-
-const options = {reporting:"no", cwd:__dirname,
-	ignore: "misc{,2}/**"
-}
-
+const {testName, lams, options, mocks, log} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
+ 
 describe('Projects', () => {
-	describe(testProjectName, () => {
+	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
-			messages = await lams(options,{process, console})
-			console.log(messages)
+			log({options})
+			messages = await lams(options,{process, console});
+			log(messages.filter(m=>m.rule=="F3"))
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -33,11 +24,18 @@ describe('Projects', () => {
 				level: "error"
 			});
 		});
-		it("it should check exactly one explore", ()=> {
+		it("it should provide correct aggregate info (1 match, 0 exempt, 1 error)", ()=> {
 			expect({messages}).toContainMessage({
-				rule: "E1",
+				rule: "F3",
 				level: "info",
-				description: "Evaluated 1 matches, with 0 exempt and 0 erroring"
+				description: "Evaluated 1 matches, with 0 exempt and 1 erroring"
+			});
+		});
+
+		it("it should error on F3 (counts must be filtered)", ()=> {
+			expect({messages}).toContainMessage({
+				rule: "F3",
+				level: "error"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/18-unexempted-errors/f3/test.view.lkml
+++ b/__tests__/dummy-projects/18-unexempted-errors/f3/test.view.lkml
@@ -1,0 +1,11 @@
+view: user {
+	# Would need this exemption to pass
+	# rule_exemptions: {
+	#	F3: "F3 is locally exempt"
+	# }
+	sql_table_name: user ;;
+
+	measure: ct {
+		type: count
+	}
+}

--- a/__tests__/dummy-projects/18-unexempted-errors/k1/index.test.js
+++ b/__tests__/dummy-projects/18-unexempted-errors/k1/index.test.js
@@ -1,22 +1,11 @@
-const lams = require('../../../index.js')
-const mocks = require('../../../lib/mocks.js')
-const path= require('path')
-require('../../../lib/expect-to-contain-message');
-const log = x=>console.log(x)
-const testProjectName = __dirname.split(path.sep).slice(-1)[0];
-
-
-const options = {reporting:"no", cwd:__dirname,
-	ignore: "misc{,2}/**"
-}
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
 
 describe('Projects', () => {
-	describe(testProjectName, () => {
+	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
 			messages = await lams(options,{process, console})
-			console.log(messages)
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -33,11 +22,10 @@ describe('Projects', () => {
 				level: "error"
 			});
 		});
-		it("it should check exactly one explore", ()=> {
+		it("it should error on K1 (pk naming convention used)", ()=> {
 			expect({messages}).toContainMessage({
-				rule: "E1",
-				level: "info",
-				description: "Evaluated 1 matches, with 0 exempt and 0 erroring"
+				rule: "K1",
+				level: "error"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/18-unexempted-errors/k1/test.view.lkml
+++ b/__tests__/dummy-projects/18-unexempted-errors/k1/test.view.lkml
@@ -1,0 +1,17 @@
+view: user {
+	# Would need this exemption to pass
+	# rule_exemptions: {
+	#	K1: "This is not implementing the primary key naming convention"
+	# }
+
+	sql_table_name: user ;;
+
+	dimension: info {
+		description: "Something about this table"
+	}
+
+	dimension: id {
+		primary_key: yes
+		# I have decided not to follow the K1 naming convention, and exempted the view from this rule
+	}
+}

--- a/__tests__/dummy-projects/18-unexempted-errors/k3/index.test.js
+++ b/__tests__/dummy-projects/18-unexempted-errors/k3/index.test.js
@@ -1,22 +1,11 @@
-const lams = require('../../../index.js')
-const mocks = require('../../../lib/mocks.js')
-const path= require('path')
-require('../../../lib/expect-to-contain-message');
-const log = x=>console.log(x)
-const testProjectName = __dirname.split(path.sep).slice(-1)[0];
-
-
-const options = {reporting:"no", cwd:__dirname,
-	ignore: "misc{,2}/**"
-}
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
 
 describe('Projects', () => {
-	describe(testProjectName, () => {
+	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
 			messages = await lams(options,{process, console})
-			console.log(messages)
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -33,11 +22,17 @@ describe('Projects', () => {
 				level: "error"
 			});
 		});
-		it("it should check exactly one explore", ()=> {
+		it("it should error on K3 (key dimensions first)", ()=> {
 			expect({messages}).toContainMessage({
-				rule: "E1",
+				rule: "K3",
+				level: "error"
+			});
+		});
+		it("it should provide correct aggregate info (1 match, 0 exempt, 1 error)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "F3",
 				level: "info",
-				description: "Evaluated 1 matches, with 0 exempt and 0 erroring"
+				description: "Evaluated 1 matches, with 0 exempt and 1 erroring"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/18-unexempted-errors/k3/test.view.lkml
+++ b/__tests__/dummy-projects/18-unexempted-errors/k3/test.view.lkml
@@ -1,0 +1,14 @@
+view: user {
+	# Would need this exemption to pass linting
+	# rule_exemptions: {
+	#	K3: "This view has non-key dimensions first, against K3, but K3 is globally exempt"
+	# }
+
+	sql_table_name: user ;;
+
+	dimension: info {
+		description: "Something about this table"
+	}
+
+	dimension: pk1_user_id {}
+}

--- a/__tests__/dummy-projects/18-unexempted-errors/t8/index.test.js
+++ b/__tests__/dummy-projects/18-unexempted-errors/t8/index.test.js
@@ -1,22 +1,11 @@
-const lams = require('../../../index.js')
-const mocks = require('../../../lib/mocks.js')
-const path= require('path')
-require('../../../lib/expect-to-contain-message');
-const log = x=>console.log(x)
-const testProjectName = __dirname.split(path.sep).slice(-1)[0];
-
-
-const options = {reporting:"no", cwd:__dirname,
-	ignore: "misc{,2}/**"
-}
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
 
 describe('Projects', () => {
-	describe(testProjectName, () => {
+	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
 			messages = await lams(options,{process, console})
-			console.log(messages)
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -33,11 +22,17 @@ describe('Projects', () => {
 				level: "error"
 			});
 		});
-		it("it should check exactly one explore", ()=> {
+		it("it should on T8 (missing separator line)", ()=> {
 			expect({messages}).toContainMessage({
-				rule: "E1",
+				rule: "T8",
+				level: "error"
+			});
+		});
+		it("it should provide correct aggregate info (1 match, 0 exempt, 1 error)", ()=> {
+			expect({messages}).not.toContainMessage({
+				rule: "F3",
 				level: "info",
-				description: "Evaluated 1 matches, with 0 exempt and 0 erroring"
+				description: "Evaluated 1 matches, with 0 exempt and 1 erroring"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/18-unexempted-errors/t8/test.view.lkml
+++ b/__tests__/dummy-projects/18-unexempted-errors/t8/test.view.lkml
@@ -1,0 +1,17 @@
+view: user_product_affinity {
+	derived_table: {
+		# Would need this exemption to pass linting
+		# rule_exemptions: {
+		#	T8: "This DT is missing the --- separator from T8, but T8 is locally exempt"
+		# }
+
+		sql:
+			SELECT
+				pk2_user_id,
+				pk2_product_id,
+				COUNT(*) as ct
+			FROM order_items
+			GROUP BY 1,2
+		;;
+	}
+}

--- a/__tests__/f3.test.js
+++ b/__tests__/f3.test.js
@@ -4,29 +4,34 @@ require('../lib/expect-to-contain-message');
 const rule = require('../rules/f3');
 const {parse} = require('lookml-parser');
 
+let F3 = {rule: 'F3'};
+let error = {level: 'error'};
+
+let summary = (m=1, ex=0, er=1) => ({
+	level: 'info',
+	description: `Evaluated ${m} matches, with ${ex} exempt and ${er} erroring`,
+});
+
 describe('Rules', () => {
 	describe('F3', () => {
-		let failMessageF3 = {
-			rule: 'F3',
-			exempt: false,
-			level: 'error',
-		};
-
 		it('should not error if there are no files', () => {
 			let result = rule(parse(``));
-			expect(result).not.toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(0, 0, 0)});
+			expect(result).not.toContainMessage({...F3, ...error});
 		});
 
 		it('should not error if there are no views', () => {
 			let result = rule(parse(`files:{} files:{}`));
-			expect(result).not.toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(0, 0, 0)});
+			expect(result).not.toContainMessage({...F3, ...error});
 		});
 
 		it('should not error for a view with no fields', () => {
 			let result = rule(parse(`files:{} files:{
 				view: foo {}
 			}`));
-			expect(result).not.toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(0, 0, 0)});
+			expect(result).not.toContainMessage({...F3, ...error});
 		});
 
 		it('should error for a measure with a type:count and no filter', () => {
@@ -35,7 +40,8 @@ describe('Rules', () => {
 					measure: bar { type: count }
 				}
 			}`));
-			expect(result).toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(1, 0, 1)});
+			expect(result).toContainMessage({...F3, ...error});
 		});
 
 		it('should not error for a measure with a type:count and 1 filter', () => {
@@ -50,7 +56,8 @@ describe('Rules', () => {
 					}
 				}
 			}`));
-			expect(result).not.toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(1, 0, 0)});
+			expect(result).not.toContainMessage({...F3, ...error});
 		});
 
 		it('should not error for a measure with a type:count and 2 filter', () => {
@@ -69,7 +76,8 @@ describe('Rules', () => {
 					}
 				}
 			}`));
-			expect(result).not.toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(1, 0, 0)});
+			expect(result).not.toContainMessage({...F3, ...error});
 		});
 
 		it('should not error for an F3 exempted view', () => {
@@ -79,7 +87,8 @@ describe('Rules', () => {
 					measure: bar { type:count }
 				}
 			}`));
-			expect(result).not.toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(1, 1, 0)});
+			expect(result).not.toContainMessage({...F3, ...error});
 		});
 
 		it('should not error for an F3 exempted field', () => {
@@ -91,7 +100,8 @@ describe('Rules', () => {
 					}
 				}
 			}`));
-			expect(result).not.toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(1, 1, 0)});
+			expect(result).not.toContainMessage({...F3, ...error});
 		});
 
 		it('should error for an F3 exempted field if no reason is specified', () => {
@@ -103,7 +113,8 @@ describe('Rules', () => {
 					}
 				}
 			}`));
-			expect(result).toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(1, 0, 1)});
+			expect(result).toContainMessage({...F3, ...error});
 		});
 
 		it('should error for an otherwise exempted view', () => {
@@ -113,7 +124,8 @@ describe('Rules', () => {
 					measure: bar { type: count }
 				}
 			}`));
-			expect(result).toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(1, 0, 1)});
+			expect(result).toContainMessage({...F3, ...error});
 		});
 
 		it('should error for an otherwise exempted field', () => {
@@ -125,7 +137,8 @@ describe('Rules', () => {
 					}
 				}
 			}`));
-			expect(result).toContainMessage(failMessageF3);
+			expect(result).toContainMessage({...F3, ...summary(1, 0, 1)});
+			expect(result).toContainMessage({...F3, ...error});
 		});
 	});
 });

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,7 @@
 # LAMS Docker Image
 
+**Note:** This configuration is out of date and may not work with LAMS v2. Please review [v2 release notes](https://looker-open-source.github.io/release-notes/v2) for details. In particular, look for error messages on the console's standard output rather than a file output to be committed back to the repo. 
+
 This is a fully functional Jenkins Server with a pre-configured job that is triggered by a webhook from a specified LookML Git repo, lints the branch invoking the job, commits the lint results back into the branch and sets a status to the commits. 
 
 <a name=docker_run></a>

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -33,22 +33,6 @@ jobs:
       run: npm install -g @looker/look-at-me-sideways@2
     - name: Run LAMS
       # See [PRIVACY.md](https://github.com/looker-open-source/look-at-me-sideways/blob/master/PRIVACY.md)
-      run: lams --reporting=... || echo "ERROR=true" >> $GITHUB_ENV
-    - name: Commit changes (e.g., issues.md)
-      run: |
-        git add .
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git commit -m "LAMS feedback" -a
-    - name: Push changes
-      uses: ad-m/github-push-action@02b0b75d447f0098d40d0d65a3e6cdf2119e6f60
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{github.ref}}
-    - name: Set status
-      run: |
-        if [ "$ERROR" ]; then
-          exit 1
-        fi
+      run: lams --reporting=... --report-license-key=... --report-user=...
 ```
 <!-- {% endraw %}) -->

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -3,6 +3,8 @@ favicon: img/logo.png
 ---
 # Running LAMS via GitLab CI
 
+**Note:** This example was prepared for v1 of LAMS, though updating it for v2 should be straightforward. Please review [v2 release notes](https://looker-open-source.github.io/release-notes/v2) for details. In particular, look for error messages on the console's standard output rather than a file output to be committed back to the repo. 
+
 This example shows how to run LAMS with GitLab CI and was contributed by [PieterjanCriel](https://github.com/PieterjanCriel). Thanks!
 
 ## Instructions
@@ -18,7 +20,7 @@ RUN apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testin
  apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ add \
  nodejs nodejs-npm
 
-RUN  npm i -g @looker/look-at-me-sideways@2 --unsafe-perm
+RUN  npm i -g @looker/look-at-me-sideways@1 --unsafe-perm
 
 CMD ["/bin/sh"]
 ```

--- a/lib/test-commons.js
+++ b/lib/test-commons.js
@@ -1,0 +1,18 @@
+const lams = require('../index.js');
+const mocks = require('./mocks.js');
+const path= require('path');
+require('./expect-to-contain-message');
+const log = (x)=>console.log(x);
+
+module.exports = function TestCommons(dirname, {
+	dirnameOffset=-1,
+}) {
+	return {
+		lams,
+		mocks,
+		path,
+		log,
+		testName: dirname.split(path.sep).slice(dirnameOffset).join(' > '),
+		options: {reporting: 'no', cwd: dirname},
+	};
+};

--- a/rules/e1.js
+++ b/rules/e1.js
@@ -52,7 +52,7 @@ module.exports = function(
 	}
 	messages.push({
 		rule, level: 'info',
-		description: `Evaluated ${matchCt} joins, with ${exemptionCt} exempt and ${errorCt} erroring`,
+		description: `Evaluated ${matchCt} matches, with ${exemptionCt} exempt and ${errorCt} erroring`,
 	});
 	return {
 		messages,

--- a/rules/e2.js
+++ b/rules/e2.js
@@ -142,7 +142,7 @@ module.exports = function(
 	}
 	messages.push({
 		rule, level: 'info',
-		description: `Evaluated ${matchCt} joins, with ${exemptionCt} exempt and ${errorCt} erroring`,
+		description: `Evaluated ${matchCt} matches, with ${exemptionCt} exempt and ${errorCt} erroring`,
 	});
 	return {
 		messages,

--- a/rules/f1.js
+++ b/rules/f1.js
@@ -93,7 +93,7 @@ module.exports = function(
 	}
 	messages.push({
 		rule, level: 'info',
-		description: `Evaluated ${matchCt} fields, with ${exemptionCt} exempt and ${errorCt} erroring`,
+		description: `Evaluated ${matchCt} matches, with ${exemptionCt} exempt and ${errorCt} erroring`,
 	});
 	return {
 		messages,

--- a/rules/f2.js
+++ b/rules/f2.js
@@ -49,7 +49,7 @@ module.exports = function(
 	}
 	messages.push({
 		rule, level: 'info',
-		description: `Evaluated ${matchCt} fields, with ${exemptionCt} exempt and ${errorCt} erroring`,
+		description: `Evaluated ${matchCt} matches, with ${exemptionCt} exempt and ${errorCt} erroring`,
 	});
 	return {
 		messages,

--- a/rules/f3.js
+++ b/rules/f3.js
@@ -6,10 +6,9 @@ module.exports = function(
 ) {
 	let messages = [];
 	let rule = 'F3';
-	let exempt;
-	if (exempt = getExemption(project.manifest, rule)) {
+	if (getExemption(project.manifest, rule)) {
 		messages.push({
-			rule, exempt, level: 'info', location: 'project',
+			rule, level: 'info', location: 'project',
 			path: `/projects/${project.name}/files/manifest.lkml`,
 			description: 'Project-level rule exemption',
 		});
@@ -28,7 +27,9 @@ module.exports = function(
 					continue;
 				}
 				matchCt++;
-				let exempt = getExemption(field, rule) || getExemption(view, rule) || getExemption(file, rule);
+				let exempt = getExemption(field, rule)
+					|| getExemption(view, rule)
+					|| getExemption(file, rule);
 				if (exempt) {
 					exemptionCt++; continue;
 				}
@@ -38,7 +39,7 @@ module.exports = function(
 				if (field.filters === undefined) {
 					errorCt++;
 					messages.push({
-						location, path, rule, exempt, level: 'error',
+						location, path, rule, level: 'error',
 						description: `Type:count measure at ${location} does not have a filter applied`,
 					});
 				}
@@ -47,7 +48,7 @@ module.exports = function(
 	}
 	messages.push({
 		rule, level: 'info',
-		description: `Evaluated ${matchCt} count measures, with ${exemptionCt} exempt and ${errorCt} erroring`,
+		description: `Evaluated ${matchCt} matches, with ${exemptionCt} exempt and ${errorCt} erroring`,
 	});
 	return {
 		messages,

--- a/rules/f4.js
+++ b/rules/f4.js
@@ -49,7 +49,7 @@ module.exports = function(
 	}
 	messages.push({
 		rule, level: 'info',
-		description: `Evaluated ${matchCt} fields, with ${exemptionCt} exempt and ${errorCt} erroring`,
+		description: `Evaluated ${matchCt} matches, with ${exemptionCt} exempt and ${errorCt} erroring`,
 	});
 	return {
 		messages,

--- a/rules/k1-2-3-4.js
+++ b/rules/k1-2-3-4.js
@@ -5,15 +5,31 @@ module.exports = function(
 	project,
 ) {
 	let messages = [];
-	let globalExemptions = {};
+
+	if (getExemption(project.manifest, 'T2')) {
+		messages.push({
+			rule: 'T2', level: 'info', location: 'project',
+			path: `/projects/${project.name}/files/manifest.lkml`,
+			description: `T2 covers all of T3-10. Project-level exemption: ${getExemption(project.manifest, 'T2')}`,
+		});
+		return {messages};
+	}
+
+	let ruleIds = ['K1', 'K2', 'K3', 'K4'];
+	let rules = {};
 	let allExempted = true;
-	for (let rule of ['K1', 'K2', 'K3', 'K4']) {
-		globalExemptions[rule] = getExemption(project.manifest, rule);
-		if (globalExemptions[rule]) {
+	for (let rule of ruleIds) {
+		rules[rule] = {
+			globallyExempt: getExemption(project.manifest, rule),
+			exemptions: 0,
+			errors: 0,
+		};
+		if (rules[rule].globallyExempt) {
 			messages.push({
 				rule, level: 'info', location: 'project',
+				exempt: rules[rule].globallyExempt,
 				path: `/projects/${project.name}/files/manifest.lkml`,
-				description: `Project-level exemption: ${globalExemptions[rule]}`,
+				description: `Project-level exemption: ${rules[rule].globallyExempt}`,
 			});
 		} else {
 			allExempted = false;
@@ -22,134 +38,119 @@ module.exports = function(
 	if (allExempted) {
 		return {messages};
 	}
+
 	const pkNamingConvention = (d) => d.$name.match(/^([0-9]+pk|pk[0-9]+)_([a-z0-9A-Z_]+)$/);
 	const unique = (x, i, arr) => arr.indexOf(x) === i;
 	let files = project.files || [];
+
 	let matchCt = 0;
 	for (let file of files) {
 		let rule;
 		let views = Object.values(file.view || {});
 		for (let view of views) {
-			matchCt++;
 			let location = 'view: ' + view.$name;
 			let path = '/projects/' + project.name + '/files/' + file.$file_path + '#view:' + view.$name;
-			let pkDimensions = (Object.values(view.dimension || {})).filter(pkNamingConvention);
-			{/* Field-only view exemption */
-				if (!view.derived_table && !view.sql_table_name && !view.extends) {
-					for (let rule of ['K1', 'K2', 'K3', 'K4']) {
-						if (globalExemptions[rule]) {
-							continue;
-						}
-						messages.push({
-							location, path, rule, level: 'verbose',
-							description: `Field-only view ${view.$name} is not subject to Primary Key Dimension rules`,
-						});
-					}
-					continue;
+
+			/* Skip field-only views */
+			if (!view.derived_table && !view.sql_table_name && !view.extends) {
+				messages.push({
+					location, path, rule: 'K1', level: 'verbose',
+					description: `Field-only view ${view.$name} is not subject to Primary Key Dimension rules K1-K4`,
+				});
+				continue;
+			}
+
+			let exempt = (ruleId) =>
+				getExemption(project.manifest, ruleId)
+				|| getExemption(file, ruleId)
+				|| getExemption(view, ruleId);
+
+			matchCt++;
+			for (let r of ruleIds) {
+				if (exempt(r)) {
+					rules[r].exemptions++;
 				}
 			}
+
+			let pkDimensions = (Object.values(view.dimension || {})).filter(pkNamingConvention);
+
 			rule = 'K1';
-			if (!globalExemptions[rule]) {
-				let exempt = getExemption(view, rule) || getExemption(file, rule);
-				if (!pkDimensions.length) {
+			if (!pkDimensions.length) {
+				if (!exempt(rule)) {
+					rules[rule].errors++;
 					messages.push({
-						location, path, rule, exempt, level: 'error',
+						location, path, rule, level: 'error',
 						description: 'No Primary Key Dimensions found in ' + view.$name,
 					});
-					continue;
 				}
-				messages.push({
-					location, path, rule, exempt, level: 'verbose',
-					description: '1 or more Primary Key Dimensions found in ' + view.$name,
-				});
+				continue;
 			}
+
 			rule = 'K2';
-			if (!globalExemptions[rule]) {
-				let declaredNs = pkDimensions.map(pkNamingConvention).map((match) => match[1].replace('pk', '')).filter(unique);
-				// let rule = 'K2';
-				let exempt = getExemption(view, rule) || getExemption(file, rule);
-				if (declaredNs.length > 1) {
+			let declaredNs = pkDimensions.map(pkNamingConvention).map((match) => match[1].replace('pk', '')).filter(unique);
+			if (declaredNs.length > 1) {
+				if (!exempt(rule)) {
+					rules[rule].errors++;
 					messages.push({
-						location, path, rule, exempt, level: 'error',
+						location, path, rule, level: 'error',
 						description: `Different Primary Key Dimensions in ${view.$name} declare different column counts: ${declaredNs.join(', ')}`,
 					});
 					continue;
 				}
-				let n = parseInt(declaredNs[0]);
-				if (n != pkDimensions.length && n !== 0) {
+			}
+
+			let n = parseInt(declaredNs[0]);
+			if (n != pkDimensions.length && n !== 0) {
+				if (!exempt(rule)) {
+					rules[rule].errors++;
 					messages.push({
-						location, path, rule, exempt, level: 'error',
+						location, path, rule, level: 'error',
 						description: `View ${view.$name} has ${pkDimensions.length} Primary Key Dimension(s) but their names declare ${declaredNs[0]} columns`,
 					});
 					continue;
 				}
-				messages.push({
-					location, path, rule, exempt, level: 'verbose',
-					description: `Primary Key Dimensions found in ${view.$name} are appropriately numbered`,
-				});
 			}
+
 			rule = 'K3';
-			if (!globalExemptions[rule]) {
-				let exempt = getExemption(view, rule) || getExemption(file, rule);
-				let d;
-				for (d=0; d<pkDimensions.length; d++) {
-					let dimensions = Object.values(view.dimension || {});
-					let dimension = dimensions[d];
-					if (!pkNamingConvention(dimension)) {
+			let d;
+			for (d=0; d<pkDimensions.length; d++) {
+				let dimensions = Object.values(view.dimension || {});
+				let dimension = dimensions[d];
+				if (!pkNamingConvention(dimension)) {
+					if (!exempt(rule)) {
+						rules[rule].errors++;
 						messages.push({
-							location, path, rule, exempt, level: 'error',
+							location, path, rule, level: 'error',
 							description: `Primary Key Dimensions in ${view.$name} are not declared before other dimensions`,
 						});
-						break;
 					}
-				}
-				if (d===pkDimensions.length) { // All initial dimensions were checked and the loop didn't break
-					messages.push({
-						location, path, rule, exempt, level: 'verbose',
-						description: `Primary Key Dimensions found in ${view.$name} are declared before other dimensions`,
-					});
+					break;
 				}
 			}
+
 			rule = 'K4';
-			if (!globalExemptions[rule]) {
-				let badDims = pkDimensions.filter((dim) => !dim.hidden);
-				if (badDims.length) {
-					let exempt = badDims.every((d) => getExemption(d, rule)) && getExemption(badDims[0], rule)
-						|| getExemption(view, rule)
-						|| getExemption(file, rule);
+			let badDims = pkDimensions.filter((dim) => !dim.hidden);
+			if (badDims.length) {
+				if (!exempt(rule)) {
 					let dimNames = badDims.map((dim) => dim.$name).join(', ');
+					rules[rule].errors++;
 					messages.push({
-						location, path, rule, exempt, level: 'error',
+						location, path, rule, level: 'error',
 						description: `Primary Key Dimensions (${dimNames}) in ${view.$name} are not hidden`,
 						hint: `If you want the column to be user-facing, make it the sql for both a hidden Primary Key Dimension, and a separate non-hidden dimension.`,
 					});
-					continue;
-				} else {
-					messages.push({
-						location, path, rule, level: 'verbose',
-						description: `Primary Key Dimensions found in ${view.$name} are all hidden`,
-					});
 				}
-			}
-			for (let pkDimension of pkDimensions) {
-				// Return PK info for PK index in developer.md
-				if (pkDimensions.map(pkNamingConvention).map((match) => match[1].replace('pk', ''))[0] === '0') {
-					continue;
-				}
-				messages.push({
-					location, path, level: 'verbose',
-					primaryKey: pkNamingConvention(pkDimension)[2],
-					view: view.$name,
-					primaryKeys: pkDimensions.map(pkNamingConvention).map((match) => match[2]).join(', '),
-				});
+				continue;
 			}
 		}
 	}
 
-	messages.push({
-		rule: 'K1-4', level: 'info',
-		description: `Evaluated ${matchCt} views`,
-	});
+	for (let rule of ruleIds) {
+		messages.push({
+			rule, level: 'info',
+			description: `Evaluated ${matchCt} matches, with ${rules[rule].exemptions} exempt and ${rules[rule].errors} erroring`,
+		});
+	}
 	return {
 		messages,
 	};

--- a/rules/t1.js
+++ b/rules/t1.js
@@ -47,7 +47,7 @@ module.exports = function(
 
 	messages.push({
 		rule, level: 'info',
-		description: `Evaluated ${matchCt} derived tables, with ${exemptionCt} exempt and ${errorCt} erroring`,
+		description: `Evaluated ${matchCt} matches, with ${exemptionCt} exempt and ${errorCt} erroring`,
 	});
 
 	return {


### PR DESCRIPTION
As originally reported in https://github.com/looker-open-source/look-at-me-sideways/issues/84 , there were issues where some exemptions were not preventing errors from being logged.

I did an overhaul of exemption checking in a number of rules to bring all the rules into more similar exemption checking and reporting behaviors, and added more full-lint tests to check a number of rules against both project exemption, local exemption, and non-exemption scenarios

