### PR TITLE
2.1.2

### DIFF
--- a/__tests__/dummy-projects/17-local-exemptions/f3/index.test.js
+++ b/__tests__/dummy-projects/17-local-exemptions/f3/index.test.js
@@ -1,4 +1,4 @@
-const {testName, lams, options, mocks, log} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
  
 describe('Projects', () => {
 	describe(testName, () => {
@@ -6,8 +6,6 @@ describe('Projects', () => {
 		let messages
 		beforeAll( async () => {
 			messages = await lams(options,{process, console});
-
-			log(messages.filter(m=>m.rule=="F3"))
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()
@@ -32,11 +30,11 @@ describe('Projects', () => {
 			});
 		});
 
-		it("it should provide aggregate info (1 match, 1 exempt, 0 error)", ()=> {
-			expect({messages}).not.toContainMessage({
+		it("it should provide correct aggregate info (1 match, 1 exempt, 0 error)", ()=> {
+			expect({messages}).toContainMessage({
 				rule: "F3",
 				level: "info",
-				description: "Evaluated 0 matches, with 1 exempt and 0 erroring"
+				description: "Evaluated 1 matches, with 1 exempt and 0 erroring"
 			});
 		});
 	});

--- a/__tests__/dummy-projects/18-unexempted-errors/f3/index.test.js
+++ b/__tests__/dummy-projects/18-unexempted-errors/f3/index.test.js
@@ -1,13 +1,11 @@
-const {testName, lams, options, mocks, log} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
+const {testName, lams, options, mocks} = require('../../../../lib/test-commons.js')(__dirname,{dirnameOffset:-2})
  
 describe('Projects', () => {
 	describe(testName, () => {
 		let {spies, process, console} = mocks()
 		let messages
 		beforeAll( async () => {
-			log({options})
 			messages = await lams(options,{process, console});
-			log(messages.filter(m=>m.rule=="F3"))
 		})
 		it("should not error out", ()=> {
 			expect(console.error).not.toHaveBeenCalled()

--- a/__tests__/f1.test.js
+++ b/__tests__/f1.test.js
@@ -327,6 +327,22 @@ describe('Rules', () => {
 			expect(result).not.toContainMessage(error);
 		});
 
+		it('should not error for special-case 2-part references, even when there is additional whitespace', () => {
+			let result = rule(parse(`files:{} files:{
+				view: foo {
+					sql_table_name: foo ;;
+					dimension: bar1 { sql: 1 ;; }
+					dimension: baz2 { sql: {{  baz._sql  }} ;;}
+					dimension: baz3 { sql: {{  baz._value  }} ;;}
+					dimension: baz5 { sql: {{ bar._parameter_value	 }} ;;}
+					dimension: baz6 { sql: {{ baz._name
+					 }} ;;}
+				}
+			}`));
+			expect(result).toContainMessage(summary(5, 0, 0));
+			expect(result).not.toContainMessage(error);
+		});
+
 		it('should error for 2-part ._in_query references', () => {
 			let result = rule(parse(`files:{} files:{
 				view: foo {

--- a/rules/f1.js
+++ b/rules/f1.js
@@ -58,7 +58,7 @@ module.exports = function(
 					let match = value
 						.replace(/\b\d+\.\d+\b/g, '') // Remove decimals
 						.match(/(\$\{|\{\{|\{%)\s*(([^.{}]+)(\.[^.{}]+)+)\s*(%\}|\})/);
-					let parts = ((match || [])[2] || '').split('.').filter(Boolean);
+					let parts = ((match || [])[2] || '').split('.').map((p)=>p.trim()).filter(Boolean);
 					if (!parts.length) {
 						return;
 					}
@@ -84,7 +84,7 @@ module.exports = function(
 						errorCt++;
 						messages.push({
 							location, path, rule, exempt, level: 'error',
-							description: `${field.$name} references another view, ${parts[0]},  via ${match[0]}`,
+							description: `${field.$name} references another view, ${parts[0]},  via ${parts.join('.')}`,
 						});
 					}
 				});

--- a/rules/k1-2-3-4.js
+++ b/rules/k1-2-3-4.js
@@ -39,7 +39,7 @@ module.exports = function(
 		return {messages};
 	}
 
-	const pkNamingConvention = (d) => d.$name.match(/^([0-9]+pk|pk[0-9]+)_([a-z0-9A-Z_]+)$/);
+	const pkNamingConvention = (d) => d.$name.match(/^([0-9]+pk|pk[0-9]*)_([a-z0-9A-Z_]+)$/);
 	const unique = (x, i, arr) => arr.indexOf(x) === i;
 	let files = project.files || [];
 
@@ -87,7 +87,11 @@ module.exports = function(
 			}
 
 			rule = 'K2';
-			let declaredNs = pkDimensions.map(pkNamingConvention).map((match) => match[1].replace('pk', '')).filter(unique);
+			let declaredNs = pkDimensions
+				.map(pkNamingConvention)
+				.map((match) => match[1].replace('pk', ''))
+				.map((n) => (n===''?'1':n))
+				.filter(unique);
 			if (declaredNs.length > 1) {
 				if (!exempt(rule)) {
 					rules[rule].errors++;


### PR DESCRIPTION
- Fixes issue #84 - exemptions not suppressing errors for some built-in rules
- Adds many end-to-end tests for exemption behavior
- Fixes issue #63 - Support for documented pk_ shorthand in K1/K2
- Fixes issue #94 - whitespace invalidating reserved word matching for F1