### PR TITLE
Allow _link in F1

### DIFF
--- a/rules/f1.js
+++ b/rules/f1.js
@@ -77,6 +77,7 @@ module.exports = function(
 						'_parameter_value',
 						'_rendered_value',
 						'_label',
+						'_link',
 					].includes(parts[parts.length - 1])
 					) {
 						parts.pop();


### PR DESCRIPTION
Using `_link` currently triggers the F1 rule when it shouldn't. This pull request whitelists it.
Valid usecase : [Advanced drilling using liquid](https://community.looker.com/lookml-5/setting-up-looker-links-to-dashboards-and-explores-through-liquid-automation-29085)

Example : 

```
measure: total_gross_revenue {
	type: sum
	sql: ${sale_price} ;;
	value_format_name: "usd"
	filters: {
		field: is_completed_sale
		value: "yes"
	}
	drill_fields: [order_details_drill*]
	link: {
		label: "Load Customer Health Dashboard"
		url: "
		@{generate_link_variable_defaults}
		{% assign link = link_generator._link %}
		{% assign filters_mapping = 'customers.new_customer_indicator|New Customer,customers.traffic_source|Traffic Source,customers.city|Customer City,order_items.purchased_year|Purchased Date' %}
		{% assign target_dashboard = 254 %}
		@{generate_dashboard_link}
		"
	}
}

  measure: link_generator {
    hidden: yes
    type: number
    sql: 1 ;;
    drill_fields: [link_generator]
  }
```

Would currently trigger the following error : 

```
❌  	F1.....	example/d:total_gross_revenue	total_gross_revenue references another view, assign link = link_generator,  via assign link = link_generator._link %
```

I think this should not be considered as a cross-view reference.