### PR TITLE
[Issue: 167] update the logic for extracting parts for F1

### DIFF
--- a/__tests__/f1.test.js
+++ b/__tests__/f1.test.js
@@ -547,14 +547,14 @@ describe('Rules', () => {
 				view: foo {
 					sql_table_name: foo ;;
 					dimension: bar { 
-            html: {% if bat._value == "usd" or bat._value == "cad" %}
-              <p>\${{rendered_value}}</p>
-              {% elsif bat._value == "eur" %}
-              <p>€{{rendered_value}}</p>
-              {% else %}
-              <p>{{rendered_value}}</p>
-              {% endif %} ;;
-          }
+						html: {% if bat._value == "usd" or bat._value == "cad" %}
+							<p>\${{rendered_value}}</p>
+							{% elsif bat._value == "eur" %}
+							<p>€{{rendered_value}}</p>
+							{% else %}
+							<p>{{rendered_value}}</p>
+							{% endif %} ;;
+						}
 				}
 			}`));
 			expect(result).toContainMessage(summary(1, 0, 0));
@@ -566,14 +566,14 @@ describe('Rules', () => {
 				view: foo {
 					sql_table_name: foo ;;
 					dimension: bar { 
-            html: {% if bat._value == "usd" or baz.bat._value == "cad" %}
-              <p>\${{rendered_value}}</p>
-              {% elsif bat._value == "eur" %}
-              <p>€{{rendered_value}}</p>
-              {% else %}
-              <p>{{rendered_value}}</p>
-              {% endif %} ;;
-          }
+						html: {% if bat._value == "usd" or baz.bat._value == "cad" %}
+							<p>\${{rendered_value}}</p>
+							{% elsif bat._value == "eur" %}
+							<p>€{{rendered_value}}</p>
+							{% else %}
+							<p>{{rendered_value}}</p>
+							{% endif %} ;;
+						}
 				}
 			}`));
 			expect(result).toContainMessage(summary(1, 0, 1));

--- a/rules/f1.js
+++ b/rules/f1.js
@@ -53,8 +53,8 @@ function ruleFn(match, path, project) {
 		while ((match = regexPattern.exec(referenceContainer)) !== null) {
 			matches.push(...match[2].trim().split(' ').filter((str) => str.includes('.')).filter(Boolean));
 		}
-		// remove duplicates
-		let fieldPaths = matches.filter((item, index) => matches.indexOf(item) === index);
+
+		let fieldPaths = [...new Set(matches)]; // remove duplicates
 
 		if (!fieldPaths.length) {
 			continue;

--- a/rules/f1.js
+++ b/rules/f1.js
@@ -44,38 +44,38 @@ function ruleFn(match, path, project) {
 			continue;
 		}
 		// TODO: Currently only checking the first reference in each block/container, should loop through them all
-    let regexMatch = referenceContainer
+		let regexMatch = referenceContainer
 			.replace(/\b\d+\.\d+\b/g, '') // Remove decimals
 			.match(/(\$\{|\{\{|\{%)\s*(([^.{}]+)(\.[^.{}]+)+)\s*(%|\}\})/);
-    let partsList = ((regexMatch || [])[2] || '').split(' ').filter(str => str.includes('.')).map((p)=>p.split('.')).filter(Boolean);
+		let partsList = ((regexMatch || [])[2] || '').split(' ').filter(str => str.includes('.')).map((p)=>p.split('.')).filter(Boolean);
 
 		if (!partsList.length) {
 			continue;
 		}
-
-    filteredPartsList = partsList.filter((parts) => {
-      if (parts[0] === 'TABLE' || parts[0] === view.$name) {
-        return false;
-      }
-      // Don't treat references to TABLE or to own default alias as cross-view
-      // Don't treat references to special properties as cross-view
-      // Note: view._in_query,_is_filtered,_is_selected should not be allowed in fields
-      if ([
-        'SQL_TABLE_NAME',
-        '_sql',
-        '_value',
-        '_name',
-        '_filters',
-        '_parameter_value',
-        '_rendered_value',
-        '_label',
-        '_link',
-      ].includes(parts[parts.length - 1])
-      ) {
-        return false;
-      }
-      return true;
-    });
+		
+		filteredPartsList = partsList.filter((parts) => {
+			if (parts[0] === 'TABLE' || parts[0] === view.$name) {
+				return false;
+			}
+			// Don't treat references to TABLE or to own default alias as cross-view
+			// Don't treat references to special properties as cross-view
+			// Note: view._in_query,_is_filtered,_is_selected should not be allowed in fields
+			if ([
+				'SQL_TABLE_NAME',
+				'_sql',
+				'_value',
+				'_name',
+				'_filters',
+				'_parameter_value',
+				'_rendered_value',
+				'_label',
+				'_link',
+			].includes(parts[parts.length - 1])
+			) {
+				return false;
+			}
+			return true;
+		});
 
 		if (filteredPartsList.length > 1) {
 			messages.push({

--- a/rules/f1.js
+++ b/rules/f1.js
@@ -60,7 +60,7 @@ function ruleFn(match, path, project) {
 			continue;
 		}
 
-		// filter out field paths that don't reference another view
+		// find all of the field paths that uses cross view references
 		let crossViewFieldPaths = fieldPaths.filter((fieldPath) => {
 			let parts = fieldPath.split('.');
 			if (parts[0] === 'TABLE' || parts[0] === view.$name) {
@@ -70,7 +70,7 @@ function ruleFn(match, path, project) {
 			// Don't treat references to TABLE or to own default alias as cross-view
 			// Don't treat references to special properties as cross-view
 			// Note: view._in_query,_is_filtered,_is_selected should not be allowed in fields
-			if (parts.length == 2 && [
+			if (parts.length == 2 && [ // only matches the fields that have two parts
 				'SQL_TABLE_NAME',
 				'_sql',
 				'_value',

--- a/rules/f1.js
+++ b/rules/f1.js
@@ -70,7 +70,7 @@ function ruleFn(match, path, project) {
 			// Don't treat references to TABLE or to own default alias as cross-view
 			// Don't treat references to special properties as cross-view
 			// Note: view._in_query,_is_filtered,_is_selected should not be allowed in fields
-			if ([
+			if (parts.length == 2 && [
 				'SQL_TABLE_NAME',
 				'_sql',
 				'_value',


### PR DESCRIPTION
The logic has been updated to support multiple lines and complex logics such as

```
html: {% if bat._value == "usd" or bat._value == "cad" %}
  <p>\${{rendered_value}}</p>
  {% elsif bat._value == "eur" %}
  <p>€{{rendered_value}}</p>
  {% else %}
  <p>{{rendered_value}}</p>
  {% endif %} ;;
}
```

Here is the process:
1. remove decimals
2. extracts all of the field references
3. remove duplicates
4. loop through the list of field refers and apply the exceptional logic.
5. report the first cross-view reference error


Issue link: https://github.com/looker-open-source/look-at-me-sideways/issues/167