### PR TITLE
2025 Q1 New Rules (v4.1.0)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
 		'es6': true,
 	},
 	'parserOptions': {
-		'ecmaVersion': 2018,
+		'ecmaVersion': 2020,
 		'ecmaFeatures': {
 			'jsx': true,
 		},

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Interested? See a video of LAMS in action!
 
 ### Built-in Linter Rules
 
-The linter comes with built-in rules that can enforce rules K1-4, F1-4, E1-2, T1-2, and W1 from the [style guide](https://looker-open-source.github.io/look-at-me-sideways/rules.html).
+The linter comes with built-in rules that can enforce some rules from the [style guide](https://looker-open-source.github.io/look-at-me-sideways/rules.html).
 
-As of LAMS v3, you must opt-in via your [manifest](#manifest-configurations) to use the built-in rules. Here is an example declaration opting in to all the currently available built-in rules:
+As of LAMS v3, you must opt-in via your [manifest](#manifest-configurations) to use the built-in rules. Since the rules are opinionated, you likely want to pick and choose the ones that make sense for you. Here is an example declaration opting in to all the currently available built-in rules:
 
 ```lkml
 #LAMS
@@ -49,6 +49,12 @@ As of LAMS v3, you must opt-in via your [manifest](#manifest-configurations) to 
 #rule: E7{} # Explore label 25-char max
 #rule: T1{} # Triggers use datagroups 
 #rule: T2{} # Primary keys in DT
+#rule: H1{} # Hoist identifiers
+#rule: H2{} # Group fields
+#rule: H3{} # Sort-group groups
+#rule: H4{} # Group more
+#rule: H5{} # Hoist main view
+#rule: H6{} # Sort-group views
 #rule: W1{} # Block indentation
 ```
 

--- a/__tests__/h1.test.js
+++ b/__tests__/h1.test.js
@@ -1,0 +1,147 @@
+/* Copyright (c) 2018 Looker Data Sciences, Inc. See https://github.com/looker-open-source/look-at-me-sideways/blob/master/LICENSE.txt */
+require('../lib/expect-to-contain-message');
+
+const rule = require('../rules/h1.js');
+const {parse} = require('lookml-parser');
+const r='H1'
+
+describe('Rules', () => {
+	describe(r, () => {
+		let info = {level: 'info'};
+		let error = {level: 'error'};
+		let verbose = {level: 'verbose'};
+		let h1 = {rule: 'H1'};
+
+		it('should not match and pass if there are no models', () => {
+			let result = rule(parse(`file: foo{}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should not match and pass if there are no views', () => {
+			let result = rule(parse(`model: foo {}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass 0-pk views, with a verbose message', () => {
+			let result = rule(parse(`model: m {
+				view: log {
+					dimension: pk0_no_log_pk {
+						hidden: yes
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).toContainMessage({...h1, ...verbose});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views without hoisted fields', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: name {}
+				}
+			}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h1, ...error});
+		});
+
+		it('should pass views with hoisted dimensions', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: account_id {
+						label: "[Account ID]"
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass views with group-hoisted dimensions', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: account_id {
+						label: "Account ID"
+						group_label: "[Identifiers]"
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views only hoisted measures', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					measure: count {
+						label: "[Count]"
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h1, ...error});
+		});
+
+		it('should fail views only hoisted dimension_groups', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension_group: created {
+						label: "[Created Date]"
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h1, ...error});
+		});
+
+		it('should pass views complying with a custom prefix/suffix', () => {
+			let result = rule(parse(`
+			manifest: {rule: H1 {options: {prefix:"(" suffix:")"}}}
+			model: m {
+				view: accounts {
+					dimension: account_id {
+						label: "(Account ID)"
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass views complying with 0/2+ length prefix/suffix', () => {
+			let result = rule(parse(`
+			manifest: {rule: H1 {options: {prefix:" 🔑 " suffix:""}}}
+			model: m {
+				view: accounts {
+					dimension: account_id {
+						label: " 🔑 Account ID"
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h1, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+	});
+});

--- a/__tests__/h1.test.js
+++ b/__tests__/h1.test.js
@@ -3,7 +3,7 @@ require('../lib/expect-to-contain-message');
 
 const rule = require('../rules/h1.js');
 const {parse} = require('lookml-parser');
-const r='H1'
+const r='H1';
 
 describe('Rules', () => {
 	describe(r, () => {

--- a/__tests__/h2.test.js
+++ b/__tests__/h2.test.js
@@ -1,0 +1,148 @@
+/* Copyright (c) 2018 Looker Data Sciences, Inc. See https://github.com/looker-open-source/look-at-me-sideways/blob/master/LICENSE.txt */
+require('../lib/expect-to-contain-message');
+
+const rule = require('../rules/h2.js');
+const {parse} = require('lookml-parser');
+const r='H2'
+
+describe('Rules', () => {
+	describe(r, () => {
+		let info = {level: 'info'};
+		let error = {level: 'error'};
+		let verbose = {level: 'verbose'};
+		let h2 = {rule: 'H2'};
+
+		it('should not match and pass if there are no models', () => {
+			let result = rule(parse(`file: foo{}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should not match and pass if there are no views', () => {
+			let result = rule(parse(`model: foo {}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views with too many dimensions + dimension_groups', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension_group: dg1 {} dimension_group: dg2 {} dimension_group: dg3 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h2, ...error});
+		});
+
+		it('should fail views with too many measures', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					measure: m1 {} measure: m2 {} measure: m3 {}
+					measure: m4 {} measure: m5 {} measure: m6 {}
+					measure: m7 {} measure: m8 {} measure: m9 {}
+					measure: m10 {} measure: m11 {} measure: m12 {}
+					measure: m13 {} measure: m14 {} measure: m15 {}
+					measure: m16 {} measure: m17 {} measure: m18 {}
+					measure: m19 {} measure: m20 {} measure: m21 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h2, ...error});
+		});
+
+		it('should fail twice with too many dimensions and too many measures', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+					measure: m1 {} measure: m2 {} measure: m3 {}
+					measure: m4 {} measure: m5 {} measure: m6 {}
+					measure: m7 {} measure: m8 {} measure: m9 {}
+					measure: m10 {} measure: m11 {} measure: m12 {}
+					measure: m13 {} measure: m14 {} measure: m15 {}
+					measure: m16 {} measure: m17 {} measure: m18 {}
+					measure: m19 {} measure: m20 {} measure: m21 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 2 errors`,
+			});
+			expect(result).toContainMessage({...h2, ...error});
+		});
+
+		it('should pass views with too many dimensions but group_label', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {group_label: "d3x"}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {group_label: "d3x"}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {group_label: "d3x"}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass views complying with a custom threshold', () => {
+			let result = rule(parse(`
+			manifest: {rule: H2 {options: {threshold:21}}}
+			model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views not complying with a custom threshold', () => {
+			let result = rule(parse(`
+			manifest: {rule: H2 {options: {threshold:10}}}
+			model: m {
+				view: accounts {
+					measure: m1 {} measure: m2 {} measure: m3 {}
+					measure: m4 {} measure: m5 {} measure: m6 {}
+					measure: m7 {} measure: m8 {} measure: m9 {}
+					measure: m10 {} measure: m11 {} measure: m12 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h2, ...error});
+		});
+
+	});
+});

--- a/__tests__/h2.test.js
+++ b/__tests__/h2.test.js
@@ -3,13 +3,12 @@ require('../lib/expect-to-contain-message');
 
 const rule = require('../rules/h2.js');
 const {parse} = require('lookml-parser');
-const r='H2'
+const r='H2';
 
 describe('Rules', () => {
 	describe(r, () => {
 		let info = {level: 'info'};
 		let error = {level: 'error'};
-		let verbose = {level: 'verbose'};
 		let h2 = {rule: 'H2'};
 
 		it('should not match and pass if there are no models', () => {
@@ -143,6 +142,5 @@ describe('Rules', () => {
 			});
 			expect(result).toContainMessage({...h2, ...error});
 		});
-
 	});
 });

--- a/__tests__/h3.test.js
+++ b/__tests__/h3.test.js
@@ -43,13 +43,28 @@ describe('Rules', () => {
 			expect(result).toContainMessage({...h3, ...error});
 		});
 
-		it('should pass views with <=10 dimension_groups>', () => {
+		it('should pass views with <=10 dimension_groups', () => {
 			let result = rule(parse(`model: m {
 				view: my_view {
 					dimension_group: dg1 {} dimension_group: dg2 {} dimension_group: dg3 {}
 					dimension_group: dg4 {} dimension_group: dg5 {} dimension_group: dg6 {}
 					dimension_group: dg7 {} dimension_group: dg8 {} dimension_group: dg9 {}
 					dimension_group: dg10 {} 
+				}
+			}`));
+			expect(result).toContainMessage({...h3, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass views with hidden dimension_groups', () => {
+			let result = rule(parse(`model: m {
+				view: my_view {
+					dimension_group: dg1 {} dimension_group: dg2 {} dimension_group: dg3 {}
+					dimension_group: dg4 {} dimension_group: dg5 {} dimension_group: dg6 {}
+					dimension_group: dg7 {} dimension_group: dg8 {} dimension_group: dg9 {}
+					dimension_group: dg10 {} dimension_group: dg11 {hidden: yes}
 				}
 			}`));
 			expect(result).toContainMessage({...h3, ...info,
@@ -138,19 +153,17 @@ describe('Rules', () => {
 		it('should pass views using sort groups to comply with the threshold', () => {
 			let result = rule(parse(`model: m {
 				view: accounts {
-					view: accounts {
-						dimension: g1d1 {group_label: "A > G1"} dimension: g1d2 {group_label: "A > G1"}
-						dimension: g2d1 {group_label: "A > G2"} dimension: g2d2 {group_label: "A > G2"}
-						dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
-						dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
-						dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
-						dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
-						dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
-						dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
-						dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
-						dimension: g9d1 {group_label: "G10"} dimension: g9d2 {group_label: "G10"}
-						dimension: g9d1 {group_label: "G11"} dimension: g9d2 {group_label: "G11"}
-					}
+					dimension: g1d1 {group_label: "A > G1"} dimension: g1d2 {group_label: "A > G1"}
+					dimension: g2d1 {group_label: "A > G2"} dimension: g2d2 {group_label: "A > G2"}
+					dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
+					dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
+					dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
+					dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
+					dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
+					dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
+					dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
+					dimension: g9d1 {group_label: "G10"} dimension: g9d2 {group_label: "G10"}
+					dimension: g9d1 {group_label: "G11"} dimension: g9d2 {group_label: "G11"}
 				}
 			}`));
 			expect(result).toContainMessage({...h3, ...info,
@@ -186,19 +199,17 @@ describe('Rules', () => {
 			manifest: {rule: H3 {options: {delimiter: ": "}}}
 			model: m {
 				view: accounts {
-					view: accounts {
-						dimension: g1d1 {group_label: "A: G1"} dimension: g1d2 {group_label: "A: G1"}
-						dimension: g2d1 {group_label: "A: G2"} dimension: g2d2 {group_label: "A: G2"}
-						dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
-						dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
-						dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
-						dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
-						dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
-						dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
-						dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
-						dimension: g9d1 {group_label: "G10"} dimension: g9d2 {group_label: "G10"}
-						dimension: g9d1 {group_label: "G11"} dimension: g9d2 {group_label: "G11"}
-					}
+					dimension: g1d1 {group_label: "A: G1"} dimension: g1d2 {group_label: "A: G1"}
+					dimension: g2d1 {group_label: "A: G2"} dimension: g2d2 {group_label: "A: G2"}
+					dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
+					dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
+					dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
+					dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
+					dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
+					dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
+					dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
+					dimension: g9d1 {group_label: "G10"} dimension: g9d2 {group_label: "G10"}
+					dimension: g9d1 {group_label: "G11"} dimension: g9d2 {group_label: "G11"}
 				}
 			}`));
 			expect(result).toContainMessage({...h3, ...info,

--- a/__tests__/h3.test.js
+++ b/__tests__/h3.test.js
@@ -28,122 +28,183 @@ describe('Rules', () => {
 			expect(result).not.toContainMessage(error);
 		});
 
-		//CONTINUE HERE
-
-		it('should fail views with too many dimensions + dimension_groups', () => {
+		it('should fail views with too many dimension_groups', () => {
 			let result = rule(parse(`model: m {
-				view: accounts {
-					dimension: d1 {} dimension: d2 {} dimension: d3 {}
-					dimension: d4 {} dimension: d5 {} dimension: d6 {}
-					dimension: d7 {} dimension: d8 {} dimension: d9 {}
-					dimension: d10 {} dimension: d11 {} dimension: d12 {}
-					dimension: d13 {} dimension: d14 {} dimension: d15 {}
-					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+				view: my_view {
 					dimension_group: dg1 {} dimension_group: dg2 {} dimension_group: dg3 {}
+					dimension_group: dg4 {} dimension_group: dg5 {} dimension_group: dg6 {}
+					dimension_group: dg7 {} dimension_group: dg8 {} dimension_group: dg9 {}
+					dimension_group: dg10 {} dimension_group: dg11 {}
 				}
 			}`));
-			expect(result).toContainMessage({...h2, ...info,
+			expect(result).toContainMessage({...h3, ...info,
 				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
 			});
-			expect(result).toContainMessage({...h2, ...error});
+			expect(result).toContainMessage({...h3, ...error});
 		});
 
-		it('should fail views with too many measures', () => {
+		it('should pass views with <=10 dimension_groups>', () => {
 			let result = rule(parse(`model: m {
-				view: accounts {
-					measure: m1 {} measure: m2 {} measure: m3 {}
-					measure: m4 {} measure: m5 {} measure: m6 {}
-					measure: m7 {} measure: m8 {} measure: m9 {}
-					measure: m10 {} measure: m11 {} measure: m12 {}
-					measure: m13 {} measure: m14 {} measure: m15 {}
-					measure: m16 {} measure: m17 {} measure: m18 {}
-					measure: m19 {} measure: m20 {} measure: m21 {}
+				view: my_view {
+					dimension_group: dg1 {} dimension_group: dg2 {} dimension_group: dg3 {}
+					dimension_group: dg4 {} dimension_group: dg5 {} dimension_group: dg6 {}
+					dimension_group: dg7 {} dimension_group: dg8 {} dimension_group: dg9 {}
+					dimension_group: dg10 {} 
 				}
 			}`));
-			expect(result).toContainMessage({...h2, ...info,
+			expect(result).toContainMessage({...h3, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views with too many group_labels among dimensions', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: g1d1 {group_label: "G1"} dimension: g1d2 {group_label: "G1"}
+					dimension: g2d1 {group_label: "G2"} dimension: g2d2 {group_label: "G2"}
+					dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
+					dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
+					dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
+					dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
+					dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
+					dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
+					dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
+					dimension: g10d1 {group_label: "G10"} dimension: g10d2 {group_label: "G10"}
+					dimension: g11d1 {group_label: "G11"} dimension: g11d2 {group_label: "G11"}
+				}
+			}`));
+			expect(result).toContainMessage({...h3, ...info,
 				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
 			});
-			expect(result).toContainMessage({...h2, ...error});
+			expect(result).toContainMessage({...h3, ...error});
+		});
+
+		it('should pass views with <=10 group_labels_among dimensions>', () => {
+			let result = rule(parse(`model: m {
+				view: my_view {
+					dimension: g1d1 {group_label: "G1"} dimension: g1d2 {group_label: "G1"}
+					dimension: g2d1 {group_label: "G2"} dimension: g2d2 {group_label: "G2"}
+					dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
+					dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
+					dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
+					dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
+					dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
+					dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
+					dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
+					dimension: g9d1 {group_label: "G10"} dimension: g9d2 {group_label: "G10"}
+				}
+			}`));
+			expect(result).toContainMessage({...h3, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
 		});
 
 		it('should fail twice with too many dimensions and too many measures', () => {
 			let result = rule(parse(`model: m {
 				view: accounts {
-					dimension: d1 {} dimension: d2 {} dimension: d3 {}
-					dimension: d4 {} dimension: d5 {} dimension: d6 {}
-					dimension: d7 {} dimension: d8 {} dimension: d9 {}
-					dimension: d10 {} dimension: d11 {} dimension: d12 {}
-					dimension: d13 {} dimension: d14 {} dimension: d15 {}
-					dimension: d16 {} dimension: d17 {} dimension: d18 {}
-					dimension: d19 {} dimension: d20 {} dimension: d21 {}
-					measure: m1 {} measure: m2 {} measure: m3 {}
-					measure: m4 {} measure: m5 {} measure: m6 {}
-					measure: m7 {} measure: m8 {} measure: m9 {}
-					measure: m10 {} measure: m11 {} measure: m12 {}
-					measure: m13 {} measure: m14 {} measure: m15 {}
-					measure: m16 {} measure: m17 {} measure: m18 {}
-					measure: m19 {} measure: m20 {} measure: m21 {}
+					dimension: g1d1 {group_label: "G1"} dimension: g1d2 {group_label: "G1"}
+					dimension: g2d1 {group_label: "G2"} dimension: g2d2 {group_label: "G2"}
+					dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
+					dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
+					dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
+					dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
+					dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
+					dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
+					dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
+					dimension: g10d1 {group_label: "G10"} dimension: g10d2 {group_label: "G10"}
+					dimension: g11d1 {group_label: "G11"} dimension: g11d2 {group_label: "G11"}
+					
+					measure: g1m1 {group_label: "G1"} measure: g1m2 {group_label: "G1"}
+					measure: g2m1 {group_label: "G2"} measure: g2m2 {group_label: "G2"}
+					measure: g3m1 {group_label: "G3"} measure: g3m2 {group_label: "G3"}
+					measure: g4m1 {group_label: "G4"} measure: g4m2 {group_label: "G4"}
+					measure: g5m1 {group_label: "G5"} measure: g5m2 {group_label: "G5"}
+					measure: g6m1 {group_label: "G6"} measure: g6m2 {group_label: "G6"}
+					measure: g7m1 {group_label: "G7"} measure: g7m2 {group_label: "G7"}
+					measure: g8m1 {group_label: "G8"} measure: g8m2 {group_label: "G8"}
+					measure: g9m1 {group_label: "G9"} measure: g9m2 {group_label: "G9"}
+					measure: g10m1 {group_label: "G10"} measure: g10m2 {group_label: "G10"}
+					measure: g11m1 {group_label: "G11"} measure: g11m2 {group_label: "G11"}
 				}
 			}`));
-			expect(result).toContainMessage({...h2, ...info,
+			expect(result).toContainMessage({...h3, ...info,
 				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 2 errors`,
 			});
-			expect(result).toContainMessage({...h2, ...error});
+			expect(result).toContainMessage({...h3, ...error});
 		});
 
-		it('should pass views with too many dimensions but group_label', () => {
+		it('should pass views using sort groups to comply with the threshold', () => {
 			let result = rule(parse(`model: m {
 				view: accounts {
-					dimension: d1 {} dimension: d2 {} dimension: d3 {group_label: "d3x"}
-					dimension: d4 {} dimension: d5 {} dimension: d6 {group_label: "d3x"}
-					dimension: d7 {} dimension: d8 {} dimension: d9 {group_label: "d3x"}
-					dimension: d10 {} dimension: d11 {} dimension: d12 {}
-					dimension: d13 {} dimension: d14 {} dimension: d15 {}
-					dimension: d16 {} dimension: d17 {} dimension: d18 {}
-					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+					view: accounts {
+						dimension: g1d1 {group_label: "A > G1"} dimension: g1d2 {group_label: "A > G1"}
+						dimension: g2d1 {group_label: "A > G2"} dimension: g2d2 {group_label: "A > G2"}
+						dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
+						dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
+						dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
+						dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
+						dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
+						dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
+						dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
+						dimension: g9d1 {group_label: "G10"} dimension: g9d2 {group_label: "G10"}
+						dimension: g9d1 {group_label: "G11"} dimension: g9d2 {group_label: "G11"}
+					}
 				}
 			}`));
-			expect(result).toContainMessage({...h2, ...info,
+			expect(result).toContainMessage({...h3, ...info,
 				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
 			});
 			expect(result).not.toContainMessage(error);
 		});
 
-		it('should pass views complying with a custom threshold', () => {
-			let result = rule(parse(`
-			manifest: {rule: H2 {options: {threshold:21}}}
-			model: m {
-				view: accounts {
-					dimension: d1 {} dimension: d2 {} dimension: d3 {}
-					dimension: d4 {} dimension: d5 {} dimension: d6 {}
-					dimension: d7 {} dimension: d8 {} dimension: d9 {}
-					dimension: d10 {} dimension: d11 {} dimension: d12 {}
-					dimension: d13 {} dimension: d14 {} dimension: d15 {}
-					dimension: d16 {} dimension: d17 {} dimension: d18 {}
-					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+		it('should fail views with sort groups that don\'t help to comply with the threshold>', () => {
+			let result = rule(parse(`model: m {
+				view: my_view {
+					dimension: g1d1 {group_label: "A > G1"} dimension: g1d2 {group_label: "A > G1"}
+					dimension: g2d1 {group_label: "G2"} dimension: g2d2 {group_label: "G2"}
+					dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
+					dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
+					dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
+					dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
+					dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
+					dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
+					dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
+					dimension: g10d1 {group_label: "G10"} dimension: g10d2 {group_label: "G10"}
+					dimension: g11d1 {group_label: "G11"} dimension: g11d2 {group_label: "G11"}
 				}
 			}`));
-			expect(result).toContainMessage({...h2, ...info,
-				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
-			});
-			expect(result).not.toContainMessage(error);
-		});
-
-		it('should fail views not complying with a custom threshold', () => {
-			let result = rule(parse(`
-			manifest: {rule: H2 {options: {threshold:10}}}
-			model: m {
-				view: accounts {
-					measure: m1 {} measure: m2 {} measure: m3 {}
-					measure: m4 {} measure: m5 {} measure: m6 {}
-					measure: m7 {} measure: m8 {} measure: m9 {}
-					measure: m10 {} measure: m11 {} measure: m12 {}
-				}
-			}`));
-			expect(result).toContainMessage({...h2, ...info,
+			expect(result).toContainMessage({...h3, ...info,
 				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
 			});
-			expect(result).toContainMessage({...h2, ...error});
+			expect(result).toContainMessage({...h3, ...error});
+		});
+
+		it('should pass views using custom-delimiter sort-grouping to comply with the threshold>', () => {
+			let result = rule(parse(`
+			manifest: {rule: H3 {options: {delimiter: ": "}}}
+			model: m {
+				view: accounts {
+					view: accounts {
+						dimension: g1d1 {group_label: "A: G1"} dimension: g1d2 {group_label: "A: G1"}
+						dimension: g2d1 {group_label: "A: G2"} dimension: g2d2 {group_label: "A: G2"}
+						dimension: g3d1 {group_label: "G3"} dimension: g3d2 {group_label: "G3"}
+						dimension: g4d1 {group_label: "G4"} dimension: g4d2 {group_label: "G4"}
+						dimension: g5d1 {group_label: "G5"} dimension: g5d2 {group_label: "G5"}
+						dimension: g6d1 {group_label: "G6"} dimension: g6d2 {group_label: "G6"}
+						dimension: g7d1 {group_label: "G7"} dimension: g7d2 {group_label: "G7"}
+						dimension: g8d1 {group_label: "G8"} dimension: g8d2 {group_label: "G8"}
+						dimension: g9d1 {group_label: "G9"} dimension: g9d2 {group_label: "G9"}
+						dimension: g9d1 {group_label: "G10"} dimension: g9d2 {group_label: "G10"}
+						dimension: g9d1 {group_label: "G11"} dimension: g9d2 {group_label: "G11"}
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h3, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
 		});
 
 	});

--- a/__tests__/h3.test.js
+++ b/__tests__/h3.test.js
@@ -1,0 +1,150 @@
+/* Copyright (c) 2018 Looker Data Sciences, Inc. See https://github.com/looker-open-source/look-at-me-sideways/blob/master/LICENSE.txt */
+require('../lib/expect-to-contain-message');
+
+const rule = require('../rules/h3.js');
+const {parse} = require('lookml-parser');
+const r='H3'
+
+describe('Rules', () => {
+	describe(r, () => {
+		let info = {level: 'info'};
+		let error = {level: 'error'};
+		let verbose = {level: 'verbose'};
+		let h3 = {rule: 'H3'};
+
+		it('should not match and pass if there are no models', () => {
+			let result = rule(parse(`file: foo{}`));
+			expect(result).toContainMessage({...h3, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should not match and pass if there are no views', () => {
+			let result = rule(parse(`model: foo {}`));
+			expect(result).toContainMessage({...h3, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		//CONTINUE HERE
+
+		it('should fail views with too many dimensions + dimension_groups', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension_group: dg1 {} dimension_group: dg2 {} dimension_group: dg3 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h2, ...error});
+		});
+
+		it('should fail views with too many measures', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					measure: m1 {} measure: m2 {} measure: m3 {}
+					measure: m4 {} measure: m5 {} measure: m6 {}
+					measure: m7 {} measure: m8 {} measure: m9 {}
+					measure: m10 {} measure: m11 {} measure: m12 {}
+					measure: m13 {} measure: m14 {} measure: m15 {}
+					measure: m16 {} measure: m17 {} measure: m18 {}
+					measure: m19 {} measure: m20 {} measure: m21 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h2, ...error});
+		});
+
+		it('should fail twice with too many dimensions and too many measures', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+					measure: m1 {} measure: m2 {} measure: m3 {}
+					measure: m4 {} measure: m5 {} measure: m6 {}
+					measure: m7 {} measure: m8 {} measure: m9 {}
+					measure: m10 {} measure: m11 {} measure: m12 {}
+					measure: m13 {} measure: m14 {} measure: m15 {}
+					measure: m16 {} measure: m17 {} measure: m18 {}
+					measure: m19 {} measure: m20 {} measure: m21 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 2 errors`,
+			});
+			expect(result).toContainMessage({...h2, ...error});
+		});
+
+		it('should pass views with too many dimensions but group_label', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {group_label: "d3x"}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {group_label: "d3x"}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {group_label: "d3x"}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass views complying with a custom threshold', () => {
+			let result = rule(parse(`
+			manifest: {rule: H2 {options: {threshold:21}}}
+			model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views not complying with a custom threshold', () => {
+			let result = rule(parse(`
+			manifest: {rule: H2 {options: {threshold:10}}}
+			model: m {
+				view: accounts {
+					measure: m1 {} measure: m2 {} measure: m3 {}
+					measure: m4 {} measure: m5 {} measure: m6 {}
+					measure: m7 {} measure: m8 {} measure: m9 {}
+					measure: m10 {} measure: m11 {} measure: m12 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h2, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h2, ...error});
+		});
+
+	});
+});

--- a/__tests__/h3.test.js
+++ b/__tests__/h3.test.js
@@ -3,13 +3,12 @@ require('../lib/expect-to-contain-message');
 
 const rule = require('../rules/h3.js');
 const {parse} = require('lookml-parser');
-const r='H3'
+const r='H3';
 
 describe('Rules', () => {
 	describe(r, () => {
 		let info = {level: 'info'};
 		let error = {level: 'error'};
-		let verbose = {level: 'verbose'};
 		let h3 = {rule: 'H3'};
 
 		it('should not match and pass if there are no models', () => {
@@ -217,6 +216,5 @@ describe('Rules', () => {
 			});
 			expect(result).not.toContainMessage(error);
 		});
-
 	});
 });

--- a/__tests__/h4.test.js
+++ b/__tests__/h4.test.js
@@ -2,13 +2,12 @@ require('../lib/expect-to-contain-message');
 
 const rule = require('../rules/h4.js');
 const {parse} = require('lookml-parser');
-const r='H4'
+const r='H4';
 
 describe('Rules', () => {
 	describe(r, () => {
 		let info = {level: 'info'};
 		let error = {level: 'error'};
-		let verbose = {level: 'verbose'};
 		let h4 = {rule: 'H4'};
 
 		it('should not match and pass if there are no models', () => {
@@ -189,6 +188,5 @@ describe('Rules', () => {
 			});
 			expect(result).not.toContainMessage(error);
 		});
-
 	});
 });

--- a/__tests__/h4.test.js
+++ b/__tests__/h4.test.js
@@ -1,0 +1,194 @@
+require('../lib/expect-to-contain-message');
+
+const rule = require('../rules/h4.js');
+const {parse} = require('lookml-parser');
+const r='H4'
+
+describe('Rules', () => {
+	describe(r, () => {
+		let info = {level: 'info'};
+		let error = {level: 'error'};
+		let verbose = {level: 'verbose'};
+		let h4 = {rule: 'H4'};
+
+		it('should not match and pass if there are no models', () => {
+			let result = rule(parse(`file: foo{}`));
+			expect(result).toContainMessage({...h4, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should not match and pass if there are no views', () => {
+			let result = rule(parse(`model: foo {}`));
+			expect(result).toContainMessage({...h4, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views with too many top-level labels', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+					dimension: d22 {} dimension: d23 {} dimension: d24 {}
+					dimension: d25 {} dimension: d26 {} dimension: d27 {}
+					dimension: d28 {} dimension: d29 {} dimension: d30 {}
+					dimension: d31{}
+				}
+			}`));
+			expect(result).toContainMessage({...h4, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h4, ...error});
+		});
+
+		it('should fail twice with too many dimensions and too many measures', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+					dimension: d22 {} dimension: d23 {} dimension: d24 {}
+					dimension: d25 {} dimension: d26 {} dimension: d27 {}
+					dimension: d28 {} dimension: d29 {} dimension: d30 {}
+					dimension: d31{}
+					measure: m1 {} measure: m2 {} measure: m3 {}
+					measure: m4 {} measure: m5 {} measure: m6 {}
+					measure: m7 {} measure: m8 {} measure: m9 {}
+					measure: m10 {} measure: m11 {} measure: m12 {}
+					measure: m13 {} measure: m14 {} measure: m15 {}
+					measure: m16 {} measure: m17 {} measure: m18 {}
+					measure: m19 {} measure: m20 {} measure: m21 {}
+					measure: m22 {} measure: m23 {} measure: m24 {}
+					measure: m25 {} measure: m26 {} measure: m27 {}
+					measure: m28 {} measure: m29 {} measure: m30 {}
+					measure: m31{}
+				}
+			}`));
+			expect(result).toContainMessage({...h4, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 2 errors`,
+			});
+			expect(result).toContainMessage({...h4, ...error});
+		});
+
+		it('should pass views with too many dimensions but <=30 top-level labels>', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					view: accounts {
+						dimension: d1 {} dimension: d2 {} dimension: d3 {}
+						dimension: d4 {} dimension: d5 {} dimension: d6 {}
+						dimension: d7 {} dimension: d8 {} dimension: d9 {}
+						dimension: d10 {} dimension: d11 {} dimension: d12 {}
+						dimension: d13 {} dimension: d14 {} dimension: d15 {}
+						dimension: d16 {} dimension: d17 {} dimension: d18 {}
+						dimension: d19 {} dimension: d20 {} dimension: d21 {}
+						dimension: d22 {} dimension: d23 {} dimension: d24 {}
+						dimension: d25 {} dimension: d26 {} dimension: d27 {}
+						dimension: d28 {} dimension: d29 {}
+						dimension: g30d1 {group_label: "Junk Dims"}
+						dimension: g30d2 {group_label: "Junk Dims"}
+						dimension: g30d3 {group_label: "Junk Dims"}
+						dimension: g30d4 {group_label: "Junk Dims"}
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h4, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views with too many top-level labels, counting distinct groups', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					dimension: d1 {} dimension: d2 {} dimension: d3 {}
+					dimension: d4 {} dimension: d5 {} dimension: d6 {}
+					dimension: d7 {} dimension: d8 {} dimension: d9 {}
+					dimension: d10 {} dimension: d11 {} dimension: d12 {}
+					dimension: d13 {} dimension: d14 {} dimension: d15 {}
+					dimension: d16 {} dimension: d17 {} dimension: d18 {}
+					dimension: d19 {} dimension: d20 {} dimension: d21 {}
+					dimension: d22 {} dimension: d23 {} dimension: d24 {}
+					dimension: d25 {} dimension: d26 {} dimension: d27 {}
+					dimension: d28 {} dimension: d29 {}
+					dimension: g30d1 {group_label: "Kinda Junk"}
+					dimension: g30d2 {group_label: "Kinda Junk"}
+					dimension: g31d1 {group_label: "Very Junk"}
+					dimension: g31d2 {group_label: "Very Junk"}
+				}
+			}`));
+			expect(result).toContainMessage({...h4, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h4, ...error});
+		});
+
+		it('should pass views using sort-grouping to remain under the threshold>', () => {
+			let result = rule(parse(`model: m {
+				view: accounts {
+					view: accounts {
+						dimension: d1 {} dimension: d2 {} dimension: d3 {}
+						dimension: d4 {} dimension: d5 {} dimension: d6 {}
+						dimension: d7 {} dimension: d8 {} dimension: d9 {}
+						dimension: d10 {} dimension: d11 {} dimension: d12 {}
+						dimension: d13 {} dimension: d14 {} dimension: d15 {}
+						dimension: d16 {} dimension: d17 {} dimension: d18 {}
+						dimension: d19 {} dimension: d20 {} dimension: d21 {}
+						dimension: d22 {} dimension: d23 {} dimension: d24 {}
+						dimension: d25 {} dimension: d26 {} dimension: d27 {}
+						dimension: d28 {} dimension: d29 {}
+						dimension: g30d1 {group_label: "Junk > Kinda"}
+						dimension: g30d2 {group_label: "Junk > Kinda"}
+						dimension: g31d1 {group_label: "Junk > Very"}
+						dimension: g31d2 {group_label: "Junk > Very"}
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h4, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass views using custom-delimiter sort-grouping to remain under the threshold>', () => {
+			let result = rule(parse(`
+			manifest: {rule: H4 {options: {delimiter: ": "}}}
+			model: m {
+				view: accounts {
+					view: accounts {
+						dimension: d1 {} dimension: d2 {} dimension: d3 {}
+						dimension: d4 {} dimension: d5 {} dimension: d6 {}
+						dimension: d7 {} dimension: d8 {} dimension: d9 {}
+						dimension: d10 {} dimension: d11 {} dimension: d12 {}
+						dimension: d13 {} dimension: d14 {} dimension: d15 {}
+						dimension: d16 {} dimension: d17 {} dimension: d18 {}
+						dimension: d19 {} dimension: d20 {} dimension: d21 {}
+						dimension: d22 {} dimension: d23 {} dimension: d24 {}
+						dimension: d25 {} dimension: d26 {} dimension: d27 {}
+						dimension: d28 {} dimension: d29 {}
+						dimension: g30d1 {group_label: "Junk: Kinda"}
+						dimension: g30d2 {group_label: "Junk: Kinda"}
+						dimension: g31d1 {group_label: "Junk: Very"}
+						dimension: g31d2 {group_label: "Junk: Very"}
+					}
+				}
+			}`));
+			expect(result).toContainMessage({...h4, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+	});
+});

--- a/__tests__/h5.test.js
+++ b/__tests__/h5.test.js
@@ -1,0 +1,107 @@
+require('../lib/expect-to-contain-message');
+
+const rule = require('../rules/h5.js');
+const {parse} = require('lookml-parser');
+const r='H5'
+
+describe('Rules', () => {
+	describe(r, () => {
+		let info = {level: 'info'};
+		let error = {level: 'error'};
+		let h5 = {rule: 'H5'};
+
+		it('should not match and pass if there are no models', () => {
+			let result = rule(parse(`file: foo{}`));
+			expect(result).toContainMessage({...h5, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should not match and pass if there are no explores', () => {
+			let result = rule(parse(`model: foo {}`));
+			expect(result).toContainMessage({...h5, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass no-join explores', () => {
+			let result = rule(parse(`model: m {
+				explore: orders {}
+			}`));
+			expect(result).toContainMessage({...h5, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass hidden explores', () => {
+			let result = rule(parse(`model: m {
+				explore: orders {
+					hidden: yes
+					join: users {}
+				}
+			}`));
+			expect(result).toContainMessage({...h5, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail hidden explores, with the enforceHidden option', () => {
+			let result = rule(parse(`
+			manifest: {rule: H5 { options: { enforceHidden: yes }}}
+			model: m {
+				explore: orders {
+					hidden: yes
+					join: users {}
+				}
+			}`));
+			expect(result).toContainMessage({...h5, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h5, ...error});
+		});
+
+		it('should fail explores without a hoisted view', () => {
+			let result = rule(parse(`model: m {
+				explore: orders {
+					join: users {}
+				}
+			}`));
+			expect(result).toContainMessage({...h5, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h5, ...error});
+		});
+
+		it('should pass explores with a hoisted view', () => {
+			let result = rule(parse(`model: m {
+				explore: orders {
+					view_label: "[Orders]"
+					join: users {}
+				}
+			}`));
+			expect(result).toContainMessage({...h5, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass explores hoisting a view with a custom prefix/suffix', () => {
+			let result = rule(parse(`
+			manifest: {rule: H5 {options: {prefix:" 🏁 " suffix:""}}}
+			model: m {
+				explore: orders {
+					view_label: " 🏁 Orders"
+					join: users {}
+				}
+			}`));
+			expect(result).toContainMessage({...h5, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+	});
+});

--- a/__tests__/h5.test.js
+++ b/__tests__/h5.test.js
@@ -2,7 +2,7 @@ require('../lib/expect-to-contain-message');
 
 const rule = require('../rules/h5.js');
 const {parse} = require('lookml-parser');
-const r='H5'
+const r='H5';
 
 describe('Rules', () => {
 	describe(r, () => {

--- a/__tests__/h6.test.js
+++ b/__tests__/h6.test.js
@@ -1,0 +1,190 @@
+/* Copyright (c) 2018 Looker Data Sciences, Inc. See https://github.com/looker-open-source/look-at-me-sideways/blob/master/LICENSE.txt */
+require('../lib/expect-to-contain-message');
+
+const rule = require('../rules/h6.js');
+const {parse} = require('lookml-parser');
+const r='H6'
+
+describe('Rules', () => {
+	describe(r, () => {
+		let info = {level: 'info'};
+		let error = {level: 'error'};
+		let verbose = {level: 'verbose'};
+		let h6 = {rule: 'H6'};
+
+		it('should not match and pass if there are no models', () => {
+			let result = rule(parse(`file: foo{}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should not match and pass if there are no explores', () => {
+			let result = rule(parse(`model: foo {}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 0 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail explores with too many view labels', () => {
+			let result = rule(parse(`model: m {
+				explore: e {
+					join: v1 {} join: v2 {} join: v3 {}
+					join: v4 {} join: v5 {} join: v6 {}
+					join: v7 {} join: v8 {} join: v9 {}
+					join: v10 {} join: v11 {} join: v12 {}
+					join: v13 {} join: v14 {} join: v15 {}
+					join: v16 {} join: v17 {} join: v18 {}
+					join: v19 {} join: v20 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h6, ...error});
+		});
+
+		it('should pass explores with <=20 view labels>', () => {
+			let result = rule(parse(`model: m {
+				explore: e {
+					join: v1 {} join: v2 {} join: v3 {}
+					join: v4 {} join: v5 {} join: v6 {}
+					join: v7 {} join: v8 {} join: v9 {}
+					join: v10 {} join: v11 {} join: v12 {}
+					join: v13 {} join: v14 {} join: v15 {}
+					join: v16 {} join: v17 {} join: v18 {}
+					join: v19 {}
+				}
+			}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass explores using sort groups to comply with the threshold', () => {
+			let result = rule(parse(`model: m {
+				explore: e {
+					join: v1 {} join: v2 {} join: v3 {}
+					join: v4 {} join: v5 {} join: v6 {}
+					join: v7 {} join: v8 {} join: v9 {}
+					join: v10 {} join: v11 {} join: v12 {}
+					join: v13 {} join: v14 {} join: v15 {}
+					join: v16 {} join: v17 {} join: v18 {}
+					join: v19 {view_label: "Junk > V19"}
+					join: v20 {view_label: "Junk > V20"}
+				}
+			}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+
+		it('should pass explores using sort groups (including prefix-only) to comply with the threshold', () => {
+			let result = rule(parse(`model: m {
+				explore: e {
+					join: v1 {} join: v2 {} join: v3 {}
+					join: v4 {} join: v5 {} join: v6 {}
+					join: v7 {} join: v8 {} join: v9 {}
+					join: v10 {} join: v11 {} join: v12 {}
+					join: v13 {} join: v14 {} join: v15 {}
+					join: v16 {} join: v17 {} join: v18 {}
+					join: v19 {}
+					join: v20 {view_label: "V19 > More"}
+				}
+			}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass explores using sort groups (including explore) to comply with the threshold', () => {
+			let result = rule(parse(`model: m {
+				explore: e {
+					view_label: "E > Base"
+					join: v1 {} join: v2 {} join: v3 {}
+					join: v4 {} join: v5 {} join: v6 {}
+					join: v7 {} join: v8 {} join: v9 {}
+					join: v10 {} join: v11 {} join: v12 {}
+					join: v13 {} join: v14 {} join: v15 {}
+					join: v16 {} join: v17 {} join: v18 {}
+					join: v19 {}
+					join: v20 {view_label: "E > More"}
+				}
+			}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should fail views with sort groups that don\'t help to comply with the threshold>', () => {
+			let result = rule(parse(`model: m {
+				explore: e {
+					join: v1 {} join: v2 {} join: v3 {}
+					join: v4 {} join: v5 {} join: v6 {}
+					join: v7 {} join: v8 {} join: v9 {}
+					join: v10 {} join: v11 {} join: v12 {}
+					join: v13 {} join: v14 {} join: v15 {}
+					join: v16 {} join: v17 {} join: v18 {}
+					join: v19 {view_label: "Junk > V19"}
+					join: v20 {view_label: "Other > V20"}
+				}
+			}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 1 errors`,
+			});
+			expect(result).toContainMessage({...h6, ...error});
+		});
+
+		it('should pass views using custom-delimiter sort-grouping to comply with the threshold', () => {
+			let result = rule(parse(`
+			manifest: {rule: H6 {options: {delimiter: ": "}}}
+			model: m {
+				explore: e {
+					join: v1 {} join: v2 {} join: v3 {}
+					join: v4 {} join: v5 {} join: v6 {}
+					join: v7 {} join: v8 {} join: v9 {}
+					join: v10 {} join: v11 {} join: v12 {}
+					join: v13 {} join: v14 {} join: v15 {}
+					join: v16 {} join: v17 {} join: v18 {}
+					join: v19 {view_label: "Junk: V19"}
+					join: v20 {view_label: "Junk: V20"}
+				}
+			}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+		it('should pass views using view-level sort-grouping to comply with the threshold', () => {
+			let result = rule(parse(`
+			model: m {
+				explore: e {
+					join: v1 {} join: v2 {} join: v3 {}
+					join: v4 {} join: v5 {} join: v6 {}
+					join: v7 {} join: v8 {} join: v9 {}
+					join: v10 {} join: v11 {} join: v12 {}
+					join: v13 {} join: v14 {} join: v15 {}
+					join: v16 {} join: v17 {} join: v18 {}
+					join: v19 {view_label: "Junk > V19"}
+					join: v20 {}
+				}
+				view: v20 {
+					label: "Junk > V20"
+				}
+			}`));
+			expect(result).toContainMessage({...h6, ...info,
+				description: `Rule ${r} summary: 1 matches, 0 matches exempt, and 0 errors`,
+			});
+			expect(result).not.toContainMessage(error);
+		});
+
+	});
+});

--- a/__tests__/h6.test.js
+++ b/__tests__/h6.test.js
@@ -3,13 +3,12 @@ require('../lib/expect-to-contain-message');
 
 const rule = require('../rules/h6.js');
 const {parse} = require('lookml-parser');
-const r='H6'
+const r='H6';
 
 describe('Rules', () => {
 	describe(r, () => {
 		let info = {level: 'info'};
 		let error = {level: 'error'};
-		let verbose = {level: 'verbose'};
 		let h6 = {rule: 'H6'};
 
 		it('should not match and pass if there are no models', () => {
@@ -185,6 +184,5 @@ describe('Rules', () => {
 			});
 			expect(result).not.toContainMessage(error);
 		});
-
 	});
 });

--- a/docs/customizing-lams.md
+++ b/docs/customizing-lams.md
@@ -52,12 +52,14 @@ Here is what each part of the rule definition means:
 - **allow_exemptions:** (Optional) A yesno value that indicates whether to respect rule exemption declarations. (Default: yes)
 - **description:** (Optional) A succint human-readable description, which will be shown to developers in LAMS' output
 - **enabled:** (Optional) A yesno value that indicates whether to use the rule. (Default: yes)
+- **options:** (Optional) An object containing rule-specific key-value pairs that further specify rule behavior. Typically relevant for built-in rules that wish to allow for some degree of flexibility.
 - **match:** A [JSONpath expression](https://www.npmjs.com/package/jsonpath-plus) that describes which LookML constructs to check. This usually matches multiple times within the project, and the rule is checked once for each such match. See [Rule Matching](#rule-matching) below for more details and example match patterns.
 - **expr_rule:** A [Liyad](https://github.com/shellyln/liyad) expression that defines the logic of the rule.
-  - **Arguments:** Three arguments are made available to the expression:
+  - **Arguments:** Four arguments are made available to the expression:
     - `match`: The value matched by the match expression. (The expression is invoked once for each time the pattern is matched in your project)
     - `path`: An array containing the path to the matched LookML. For example, `['$','model','my_model']`
     - `project`: The entire LookML project, in case you need to further reference any data from it within each match
+    - `options`: An object containing any options defined in the rule configuration.
   - **Return value**
     - **true** - If your expression returns true, the test will be passed
     - **false** - If your expression returns false, the test will be failed

--- a/docs/release-notes/v3.md
+++ b/docs/release-notes/v3.md
@@ -107,3 +107,10 @@ Patches:
 
 v3.4.0 had introduced a change in behavior at the intersection of conditional comments and whitespace rule W1. Since whitespace behavior for conditional comments had not been formally defined or desrcribed, this release defines the conditional comment whitespace handling going forward, primarily chosen to mirror the in-Looker IDE behavior when a block is commented via the Ctrl+/ shortcut. Conditional comments will preserve the whitespace before the comment, consume the comment character and up to one space or tab character following the comment character and/or conditional comment token.
 
+# 4.1
+
+- Add "Hierarchy" rules: H1, H2, H3, H4, H5, H6. These rules provide suggested labeling patterns to increase organization at various levels from the field to the explore.
+- Fix file inclusion when an imported project includes a file using a "project root" (single `/` ) path
+- Fix typos in output strings (manifest loader, rule K1)
+- Allow custom rules to accept `options`
+- Added information about parser errors to the Style Guide

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -920,7 +920,39 @@
 
 	</details>
 
+<h1 id="hierarchy">Hierarchy</h1>
+<p>A key principle to avoid overwhelming users and to help them quickly find what they need, is to limit the number of available options at any given time. Besides entirely hiding things, the best way to do this is by adding hierarchy.</p>
+<p>This section provides a set of rules across different objects to suggest introducing hierarchy whenever the number of object/sub objects grows large.</p>
 
+
+<details id="h1">
+	<summary><b><a href="#h1">H1.</a></b> Hoist identifiers</summary>
+	<p></p>
+	</details>
+<details id="h2">
+	<summary><b><a href="#h2">H2.</a></b> Group fields</summary>
+	<p></p>
+	</details>
+<details id="h3">
+	<summary><b><a href="#h3">H3.</a></b> Super-group fields</summary>
+	<p></p>
+	</details>
+<details id="h4">
+	<summary><b><a href="#h4">H4.</a></b> Hoist main view</summary>
+	<p></p>
+	</details>
+<details id="h5">
+	<summary><b><a href="#h5">H5.</a></b> Super-group views</summary>
+	<p></p>
+	</details>
+<details id="h6">
+	<summary><b><a href="#h6">H6.</a></b> Group explores</summary>
+	<p></p>
+	</details>
+<details id="h7">
+	<summary><b><a href="#h7">H7.</a></b> Super-group explores</summary>
+	<p></p>
+	</details>
 
 <h1 id="whitespace">Whitespace</h1>
 <p><b>Note:</b> To enable the linter to effectively enforce whitespace-related rules, you may have to consider how conditional comments (e.g. `#LAMS`) will be pre-processed. The parser will preserve whitespace before the comment on each line, and will consume the comment character (#), the conditional comment token, and up to one space or tab character. For multi-line commented blocks, it will visually appear that there is one additional level of indentation. See <a href="https://github.com/looker-open-source/look-at-me-sideways/blob/master/__tests__/dummy-projects/33-w1-tests/">test project #33</a> for an example.</p>

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -950,9 +950,9 @@
 	#rule: H2 {options: {threshold: 30}}
 	</code>
 	</details>
-<details id="h3"> <!-- Sort group groups -->
-	<summary><b><a href="#h3">H3.</a></b> Super-group groups, when too many</summary>
-	<p>When already using group_label (or when having a number of dimension groups), if the number of groups under a view's field picker exceeds 8, use label prefixes to sort and organize groups. Separate the prefix with " > " to visually indicate hierarchy.</p>
+<details id="h3"> <!-- Sort-group groups -->
+	<summary><b><a href="#h3">H3.</a></b> Sort-group groups, when too many</summary>
+	<p>When already using group_label (or when having a number of dimension groups), if the number of groups under a view's field picker exceeds 10, use label prefixes to sort and organize groups. Separate the prefix with " > " to visually indicate hierarchy.</p>
 	<code class="block bad">
 		# Labels below aligned to help illustrate field picker
 		dimension: annual_contract_value {        group_label: "ACV" ...}
@@ -977,7 +977,7 @@
 		dimension: widgets_tv {                   group_label: "Value > TCV" ...}
 	</code>
 
-	<p><b>Note: </b>LAMS configuration can specify a different threshold to use instead of 8, and a different delimiter to use:</p>
+	<p><b>Note: </b>LAMS configuration can specify a different threshold to use instead of 10, and a different delimiter to use:</p>
 	<code class="block">
 	# Providing options in manifest.lkml
 
@@ -986,24 +986,42 @@
 	</code>
 	</details>
 <details id="h4"> <!-- Group more -->
-	<summary><b><a href="#h3">H4.</a></b> Group more, when still too many</summary>
+	<summary><b><a href="#h4">H4.</a></b> Group more, when still too many</summary>
 	<p>When already using group_label and/or sorting groups, if the number of options under a view's field picker still exceeds 30, group fields into your available groups more proactively.</p>
 	<p><b>Rationale:</b> The prior two rules provide a first line of defense by alerting developers to available features they may not know to use. However, if after making those options available, the number of options presented to a user at a time is still too large, this rule encourages developers to explicitly target reducing that overall number. Accordingly the threshold is set slightly higher.</p>
 	</details>
-<details id="h">
-	<summary><b><a href="#h">H.</a></b> Hoist main view</summary>
-	<p></p>
-	</details>
-<details id="h5">
-	<summary><b><a href="#h5">H5.</a></b> Super-group views</summary>
-	<p></p>
+<details id="h5"> <!-- Hoist main view -->
+	<summary><b><a href="#h5">H5.</a></b> Hoist main view</summary>
+	<p>Wrap an explore's base view in square brackets to visually distinguish it and hoist it to the top of the field picker.</p>
+	<p>The rule may be ignored for explores that have no joins, and for hidden explores.</p>
+	<p><b>Rationale:</b> Many or most explores in Looker follow a snowflake schema - a central fact table, and a number of many-to-one dimensional joins. Hoisting the main view that the explore represents to the top of the field picker helps visually reinforce the central/primary nature of that view within the explore.</p>
+	<code class="block good">
+	explore: orders {
+		view_label: "[Orders]"
+		...
+	</code>
+	<p><b>Note: </b>LAMS configuration can specify different prefixes/sufixes to use instead of the suggested square brackets. Make sure to use a prefix that sorts higher than other typically used characters</p>
+	<code class="block">
+	# Providing custom options in manifest.lkml
+
+	#LAMS
+	#rule: H5 {options: {
+	#   prefix: " 🔑"
+	#   suffix: ""
+	#   enforceHidden: yes
+	#}}
+	</code>
 	</details>
 <details id="h6">
-	<summary><b><a href="#h6">H6.</a></b> Group explores</summary>
+	<summary><b><a href="#h6">H.</a></b> Sort-group views</summary>
+	<p>When the numer of views in an explore's field picker exceeds 10, use label prefixes to sort and organize groups.</p>
+	</details>
+<details id="h">
+	<summary><b><a href="#h">H.</a></b> Group explores</summary>
 	<p></p>
 	</details>
-<details id="h7">
-	<summary><b><a href="#h7">H7.</a></b> Super-group explores</summary>
+<details id="h">
+	<summary><b><a href="#h7">H.</a></b> Super-group explores</summary>
 	<p></p>
 	</details>
 

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -921,7 +921,7 @@
 	</details>
 
 <h1 id="hierarchy">Hierarchy</h1>
-<p>A key principle to avoid overwhelming users and to help them quickly find what they need, is to limit the number of available options at any given time. Besides entirely hiding things, the best way to do this is by adding hierarchy.</p>
+<p>A key principle to avoid overwhelming users and to help them quickly find what they need is to limit the number of available options at any given time. Besides entirely hiding things, the best way to do this is by adding hierarchy.</p>
 <p>This section provides a set of rules across different objects to suggest introducing hierarchy whenever the number of object/sub objects grows large.</p>
 
 
@@ -1006,25 +1006,46 @@
 
 	#LAMS
 	#rule: H5 {options: {
-	#   prefix: " 🔑"
+	#   prefix: " 📊"
 	#   suffix: ""
 	#   enforceHidden: yes
 	#}}
 	</code>
 	</details>
-<details id="h6">
+<details id="h6"> <!-- Sort-group views -->
 	<summary><b><a href="#h6">H.</a></b> Sort-group views</summary>
-	<p>When the numer of views in an explore's field picker exceeds 10, use label prefixes to sort and organize groups.</p>
-	</details>
-<details id="h">
-	<summary><b><a href="#h">H.</a></b> Group explores</summary>
-	<p></p>
-	</details>
-<details id="h">
-	<summary><b><a href="#h7">H.</a></b> Super-group explores</summary>
-	<p></p>
-	</details>
+	<p>When the numer of views in an explore's field picker exceeds 20, use label prefixes to sort and organize groups.</p>
+	<code class="block good">
+	explore: orders {
+		join: user {}
+		join: first_orders {
+			view_label: "User > First Order"
+		}
+		join: first_orders {
+			view_label: "User > First Order"
+		}
+		...
+	</code>
+	<p><b>Note: </b>LAMS configuration can specify a different delimiter</p>
+	<code class="block">
+	# Providing custom options in manifest.lkml
 
+	#LAMS rule: H6 {options: {threshold: 10 delimiter: ": "}}
+	</code>
+	</details>
+<details id="h7"> <!-- Group explores -->
+	<summary><b><a href="#h7">H7.</a></b> Group explores</summary>
+	<p>When the number of visible explores in a model exceeds 10, use group_label to organize explores</p>
+	<p><b>Rationale:</b> Consolidate and group the number of options presented to users to create a more approachable explore picker.</p>
+	<p><b>Note:</b> The explore picker is populated from across multiple projects, so linting any one project can only work as a warning flag. You should evaluate your model naming/grouping while considering all projects in your instance and use the threshold option for more granular control on a per-project basis.</p>
+	</details>
+<!-- Sort-group explores
+<details id="h">
+	<summary><b><a href="#h">H.</a></b> Sort-group explores</summary>
+	<p>When the number of visible models and explore groups exceeds 10, use label prefixes to organize explore groups</p>
+	<p>Note: Although the intent of this rule is to create a more approachable explore picker for users, the explore picker is populated from multiple projects, so linting any one project can only work as a warning flag. You should evaluate the impliction of model naming/grouping while considering all projects in your instance and use the threshold option for more granular control on a per-project basis.</p>
+	</details>
+	-->
 <h1 id="whitespace">Whitespace</h1>
 <p><b>Note:</b> To enable the linter to effectively enforce whitespace-related rules, you may have to consider how conditional comments (e.g. `#LAMS`) will be pre-processed. The parser will preserve whitespace before the comment on each line, and will consume the comment character (#), the conditional comment token, and up to one space or tab character. For multi-line commented blocks, it will visually appear that there is one additional level of indentation. See <a href="https://github.com/looker-open-source/look-at-me-sideways/blob/master/__tests__/dummy-projects/33-w1-tests/">test project #33</a> for an example.</p>
 <details id="w1">

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -40,7 +40,9 @@
 <li> <a href="#other-fields">Other Fields</a></li>
 <li> <a href="#derived-tables">Derived Tables</a></li>
 <li> <a href="#explores">Explores</a></li>
-<li> <a href="#out-of-scope">Out of Scope</a></li>
+<li> <a href="#hierarchy">Hierarchy</a></li>
+<li> <a href="#whitespace">Whitespace</a></li>
+<li> <a href="#deprecated-rules">Deprecated Rules</a></li>
 </ul></nav>
 
 <h1 id="key-dimensions">Key Dimensions</h1>
@@ -1013,7 +1015,7 @@
 	</code>
 	</details>
 <details id="h6"> <!-- Sort-group views -->
-	<summary><b><a href="#h6">H.</a></b> Sort-group views</summary>
+	<summary><b><a href="#h6">H6.</a></b> Sort-group views</summary>
 	<p>When the numer of views in an explore's field picker exceeds 20, use label prefixes to sort and organize groups.</p>
 	<code class="block good">
 	explore: orders {
@@ -1026,22 +1028,23 @@
 		}
 		...
 	</code>
-	<p><b>Note: </b>LAMS configuration can specify a different delimiter</p>
+	<p><b>Note: </b>LAMS configuration can specify a different delimiter and/or threshold.</p>
 	<code class="block">
 	# Providing custom options in manifest.lkml
 
 	#LAMS rule: H6 {options: {threshold: 10 delimiter: ": "}}
 	</code>
 	</details>
-<details id="h7"> <!-- Group explores -->
-	<summary><b><a href="#h7">H7.</a></b> Group explores</summary>
+<!-- Group explores
+<details id="h...">
+	<summary><b><a href="#h...">H...</a></b> Group explores</summary>
 	<p>When the number of visible explores in a model exceeds 10, use group_label to organize explores</p>
 	<p><b>Rationale:</b> Consolidate and group the number of options presented to users to create a more approachable explore picker.</p>
 	<p><b>Note:</b> The explore picker is populated from across multiple projects, so linting any one project can only work as a warning flag. You should evaluate your model naming/grouping while considering all projects in your instance and use the threshold option for more granular control on a per-project basis.</p>
-	</details>
+	</details>-->
 <!-- Sort-group explores
-<details id="h">
-	<summary><b><a href="#h">H.</a></b> Sort-group explores</summary>
+<details id="h...">
+	<summary><b><a href="#h...">H...</a></b> Sort-group explores</summary>
 	<p>When the number of visible models and explore groups exceeds 10, use label prefixes to organize explore groups</p>
 	<p>Note: Although the intent of this rule is to create a more approachable explore picker for users, the explore picker is populated from multiple projects, so linting any one project can only work as a warning flag. You should evaluate the impliction of model naming/grouping while considering all projects in your instance and use the threshold option for more granular control on a per-project basis.</p>
 	</details>
@@ -1078,6 +1081,14 @@
 	</details>
 -->
 
+<h1 id="linter-errors">Linter Errors</h1>
+<p>In some circumstances, the linter may run into errors while running that are recoverable, and may report them along with its rule findings.</p>
+<ul>
+	<li><a href="#P0" id="p0" name="p0">P0.</a> Generic Parser Error - Any parser error other than a LookML syntax error. If visible in the chosen output format, the message's `location` property contains the path to the file.</li> 
+	<li><a href="#P1" id="p1" name="p1">P1.</a> LookML Syntax Error - The LookML file contains a unexpected syntax (after expenading any `#LAMS` conditional comments). If visible in the chosen output format, the message's `location` property contains the path to the file and a `hint` for expected syntax from the parser.</li> 
+	<li><a href="#lams1" id="lams1" name="lams1">LAMS1.</a> Unhandled Rule Error - An execution error occurred while running a rule. Please <a href="https://github.com/looker-open-source/look-at-me-sideways/issues/new?template=Blank+issue">submit a ticket</a> about this.</li>
+	<li><a href="#lams2" id="lams2" name="lams2"></a></li>LAMS2.</a> Legacy Custom Rule Error - An execution error occured while running a Javascript-based (Deprecated) custom rule</li> 
+	</ul>
 <h1 id="deprecated-rules">Deprecated Rules</h1>
 <ul>
 	<li><a href="#f7" id="f7" name="f7">F7</a> previously recommended proactively exposing "summary" measures for your dimensions. While summary measures can still be useful for select dimensions, the release of custom measures which explore users can automatically generate from a dimension in the Explore UI renders this practice no longer as important.</li>

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -18,7 +18,7 @@
 	a {color:#44B;}
 	a.subtle {color:#559; text-decoration: none;}
 	code{background-color: #EEF; color:#333;}
-	code.block {display:block; white-space: pre-wrap; max-width:90%;margin:1em 0 1.5em 0; tab-size:2em;}
+	code.block {display:block; white-space: pre-wrap; max-width:90%;margin:1em 0 1.5em 0; tab-size:2em;box-shadow: 2px 2px 10px 0px #99C;}
 	code.good.block {background-color: #EFE; box-shadow: 2px 2px 10px 0px #9C9;}
 	code.good.block::before {content:"# GOOD:"}
 	code.good.block.sql::before {content:"-- GOOD:"}
@@ -925,20 +925,73 @@
 <p>This section provides a set of rules across different objects to suggest introducing hierarchy whenever the number of object/sub objects grows large.</p>
 
 
-<details id="h1">
-	<summary><b><a href="#h1">H1.</a></b> Hoist identifiers</summary>
-	<p></p>
+<details id="h1"> <!-- Hoist identifiers -->
+	<summary><b><a href="#h1">H1.</a></b> Hoist identifier dimensions via labeling</summary>
+	<p>Wrap a view's identifying dimensions (ID, name, etc) in square brackets to visually distinguish them and hoist them to the top of the field picker. This may be done either directly on the dimension's label, or on a group label.</p>
+	<p><b>Rationale:</b> This provides a visual hint to explore users about the subject and structure of each view.</p>
+	<p>For views without primary keys or identifiers, there are no fields to hoist. If a view declares 0 primary keys via a <a href="#k1">pk-naming convention</a>, LAMS will not require any hoisting.</p>
+	<p><b>Note: </b>LAMS will not identify <i>which</i> fields should be hoisted, just suggest that some should be hoisted when none are found.</p>
+	<p><b>Note: </b>LAMS configuration can specify different prefixes/sufixes to use instead of the suggested square brackets by specifying the desired characters in </code>prefix</code> and <code>suffix</code> options. Simply make sure to use a prefix that sorts higher than other typically used characters</p>
+	<code class="block">
+	# Providing a custom format in manifest.lkml
+
+	#LAMS
+	#rule: H1 {options: {prefix: " 🔑" suffix: ""}}
+	</code>
 	</details>
-<details id="h2">
-	<summary><b><a href="#h2">H2.</a></b> Group fields</summary>
-	<p></p>
+<details id="h2"> <!-- Group fields -->
+	<summary><b><a href="#h2">H2.</a></b> Group fields, when too many</summary>
+	<p>When the number of dimensions/measures in a view's field picker exceeds 20, use `group_label` to reduce clutter.</p>
+	<p><b>Note: </b>LAMS configuration can specify a different threshold to use instead of 20:</p>
+	<code class="block">
+	# Providing options in manifest.lkml
+
+	#LAMS
+	#rule: H2 {options: {threshold: 30}}
+	</code>
 	</details>
-<details id="h3">
-	<summary><b><a href="#h3">H3.</a></b> Super-group fields</summary>
-	<p></p>
+<details id="h3"> <!-- Sort group groups -->
+	<summary><b><a href="#h3">H3.</a></b> Super-group groups, when too many</summary>
+	<p>When already using group_label (or when having a number of dimension groups), if the number of groups under a view's field picker exceeds 8, use label prefixes to sort and organize groups. Separate the prefix with " > " to visually indicate hierarchy.</p>
+	<code class="block bad">
+		# Labels below aligned to help illustrate field picker
+		dimension: annual_contract_value {        group_label: "ACV" ...}
+		dimension: widgets_annual_contract_value {group_label: "ACV" ...}
+		dimension_group: close_date {             group_label: "Close" ...}
+		dimension: incremental_acv {              group_label: "IACV" ...}
+		dimension: widgets_incremental_acv {      group_label: "IACV" ...}
+		dimension_group: start_date {             group_label: "Start" ...}
+		dimension: total_contract_value {         group_label: "TCV" ...}
+		dimension: widgets_tv {                   group_label: "TCV" ...}
+		...
+	</code>
+	<code class="block good">
+		# Labels below aligned to help illustrate field picker
+		dimension_group: close_date {             group_label: "Dates > Close" ...}
+		dimension_group: start_date {             group_label: "Dates > Start" ...}
+		dimension: annual_contract_value {        group_label: "Value > ACV" ...}
+		dimension: widgets_annual_contract_value {group_label: "Value > ACV" ...}
+		dimension: incremental_acv {              group_label: "Value > IACV" ...}
+		dimension: widgets_incremental_acv {      group_label: "Value > IACV" ...}
+		dimension: total_contract_value {         group_label: "Value > TCV" ...}
+		dimension: widgets_tv {                   group_label: "Value > TCV" ...}
+	</code>
+
+	<p><b>Note: </b>LAMS configuration can specify a different threshold to use instead of 8, and a different delimiter to use:</p>
+	<code class="block">
+	# Providing options in manifest.lkml
+
+	#LAMS
+	#rule: H3 {options: {threshold: 12 delimiter: ": "}}
+	</code>
 	</details>
-<details id="h4">
-	<summary><b><a href="#h4">H4.</a></b> Hoist main view</summary>
+<details id="h4"> <!-- Group more -->
+	<summary><b><a href="#h3">H4.</a></b> Group more, when still too many</summary>
+	<p>When already using group_label and/or sorting groups, if the number of options under a view's field picker still exceeds 30, group fields into your available groups more proactively.</p>
+	<p><b>Rationale:</b> The prior two rules provide a first line of defense by alerting developers to available features they may not know to use. However, if after making those options available, the number of options presented to a user at a time is still too large, this rule encourages developers to explicitly target reducing that overall number. Accordingly the threshold is set slightly higher.</p>
+	</details>
+<details id="h">
+	<summary><b><a href="#h">H.</a></b> Hoist main view</summary>
 	<p></p>
 	</details>
 <details id="h5">

--- a/docs/sample-custom-rule.js
+++ b/docs/sample-custom-rule.js
@@ -1,6 +1,8 @@
 /* Copyright (c) 2018 Looker Data Sciences, Inc. See https://github.com/looker-open-source/look-at-me-sideways/blob/master/LICENSE.txt */
 
-/*	This sample custom rule checks all models for a hypothetical naming convention
+/*	THIS SAMPLE IS FOR THE DEPRECATED JAVASCRIPT-BASED RULES MECHANISM
+
+	This sample custom rule checks all models for a hypothetical naming convention
 	within the model's connection string to ensure that users developing against
 	a staging/dev connection don't accidentally push that connection to prod
 

--- a/lib/custom-rule/rule-match-evaluator.js
+++ b/lib/custom-rule/rule-match-evaluator.js
@@ -19,7 +19,7 @@ module.exports = function ruleMatchEvaluator(ruleDef={}, project){
 			throw new CodeError(`Missing expr_rule in manifest/rule:${rule}`, 1);
 		}
 		try {
-			ruleFn = parser.parse(`( -> (match path project) ($last ${ruleDef.expr_rule}))`);
+			ruleFn = parser.parse(`( -> (match path project options) ($last ${ruleDef.expr_rule}))`);
 		} catch (e) {
 			throw new CodeError(`Invalid expr_rule in manifest/rule:${rule}. ${e.message||''}`, 1);
 		}

--- a/lib/loaders/manifest/manifest.js
+++ b/lib/loaders/manifest/manifest.js
@@ -93,7 +93,7 @@ async function loadManifest(
 				case LKML_PATH: contents = lkmlParser.parse(await read(spec),{conditionalCommentString});break;
 			}
 			manifestMergeMutate(manifest, contents)
-			info(`Override manifest settings read from ${specMeaning})`)
+			info(`Override manifest settings read from ${specMeaning}`)
 			messages = messages.concat(msgManifestOverview(contents,"Override","verbose"))
 		}
 		catch(e){

--- a/npm-shrinkwrap.dev.json
+++ b/npm-shrinkwrap.dev.json
@@ -13,7 +13,7 @@
         "fromentries": "^1.3.2",
         "jsonpath-plus": "^10.2.0",
         "liyad": "^0.2.4",
-        "lookml-parser": "^6.11.0",
+        "lookml-parser": "^6.11.1",
         "minimist": "^1.2.6",
         "require-from-string": "^2.0.2"
       },
@@ -3862,9 +3862,9 @@
       "dev": true
     },
     "node_modules/lookml-parser": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/lookml-parser/-/lookml-parser-6.11.0.tgz",
-      "integrity": "sha512-NIw+ViMopuuuBfP8XHpzJl57UYGMfuQ4FQp2vdAbAIVUzYlfIex19/6ZAwOOPRf3O7uOm+CVF92zw9Hkfk9yOA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/lookml-parser/-/lookml-parser-6.11.1.tgz",
+      "integrity": "sha512-UXqmqbSlKWwnCy1x3gMIkPRq5EXJk92ZGDwZjjzO3F3Mbdq3u/xWXNfwXjIvzSmf266i1NszaJtbGSig3ZaE3A==",
       "dependencies": {
         "bluebird": "^3.5.1",
         "glob": "^7.1.2",
@@ -8052,9 +8052,9 @@
       "dev": true
     },
     "lookml-parser": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/lookml-parser/-/lookml-parser-6.11.0.tgz",
-      "integrity": "sha512-NIw+ViMopuuuBfP8XHpzJl57UYGMfuQ4FQp2vdAbAIVUzYlfIex19/6ZAwOOPRf3O7uOm+CVF92zw9Hkfk9yOA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/lookml-parser/-/lookml-parser-6.11.1.tgz",
+      "integrity": "sha512-UXqmqbSlKWwnCy1x3gMIkPRq5EXJk92ZGDwZjjzO3F3Mbdq3u/xWXNfwXjIvzSmf266i1NszaJtbGSig3ZaE3A==",
       "requires": {
         "bluebird": "^3.5.1",
         "glob": "^7.1.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,7 +13,7 @@
         "fromentries": "^1.3.2",
         "jsonpath-plus": "^10.2.0",
         "liyad": "^0.2.4",
-        "lookml-parser": "^6.11.0",
+        "lookml-parser": "^6.11.1",
         "minimist": "^1.2.6",
         "require-from-string": "^2.0.2"
       },
@@ -3862,9 +3862,9 @@
       "dev": true
     },
     "node_modules/lookml-parser": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/lookml-parser/-/lookml-parser-6.11.0.tgz",
-      "integrity": "sha512-NIw+ViMopuuuBfP8XHpzJl57UYGMfuQ4FQp2vdAbAIVUzYlfIex19/6ZAwOOPRf3O7uOm+CVF92zw9Hkfk9yOA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/lookml-parser/-/lookml-parser-6.11.1.tgz",
+      "integrity": "sha512-UXqmqbSlKWwnCy1x3gMIkPRq5EXJk92ZGDwZjjzO3F3Mbdq3u/xWXNfwXjIvzSmf266i1NszaJtbGSig3ZaE3A==",
       "dependencies": {
         "bluebird": "^3.5.1",
         "glob": "^7.1.2",
@@ -8052,9 +8052,9 @@
       "dev": true
     },
     "lookml-parser": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/lookml-parser/-/lookml-parser-6.11.0.tgz",
-      "integrity": "sha512-NIw+ViMopuuuBfP8XHpzJl57UYGMfuQ4FQp2vdAbAIVUzYlfIex19/6ZAwOOPRf3O7uOm+CVF92zw9Hkfk9yOA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/lookml-parser/-/lookml-parser-6.11.1.tgz",
+      "integrity": "sha512-UXqmqbSlKWwnCy1x3gMIkPRq5EXJk92ZGDwZjjzO3F3Mbdq3u/xWXNfwXjIvzSmf266i1NszaJtbGSig3ZaE3A==",
       "requires": {
         "bluebird": "^3.5.1",
         "glob": "^7.1.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@looker/look-at-me-sideways",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@looker/look-at-me-sideways",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "dot": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/look-at-me-sideways",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A judgmental little LookML linter >_>",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fromentries": "^1.3.2",
     "jsonpath-plus": "^10.2.0",
     "liyad": "^0.2.4",
-    "lookml-parser": "^6.11.0",
+    "lookml-parser": "^6.11.1",
     "minimist": "^1.2.6",
     "require-from-string": "^2.0.2"
   },

--- a/rules/h1.js
+++ b/rules/h1.js
@@ -1,0 +1,41 @@
+
+const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
+
+module.exports = function(
+	project,
+) {
+	let ruleDef = {
+		$name: 'H1',
+		match: `$.model.*.view.*`,
+
+		ruleFn,
+	};
+	let messages = checkCustomRule(ruleDef, project, {ruleSource: 'internal'});
+
+	return {messages};
+};
+
+function ruleFn(match, path, project, options={}) {
+	const prefix = options.prefix!==undefined ? options.prefix : "["
+	const suffix = options.suffix!==undefined ? options.suffix : "]"
+	const view = match;
+	const dimNames = Object.keys(view?.dimension || {})
+	if(dimNames.some(d => d.match(/^pk0_/))){
+		return {level:"verbose",description:"Field hoisting not relevant for 0-PK views"}
+	}
+	const labels = []
+		.concat(Object.values(view?.dimension || {}).map(dim => dim.label))
+		.concat(Object.values(view?.dimension || {}).map(dim => dim.group_label))
+		// Dimension groups being for dates, they don't really work as identifiers.
+		// Omitting them for now, but may revisit the decision in the future
+		//.concat(Object.values(view?.dimension_group || {}).map(dg => dg.label))
+		.filter(l => typeof l==="string")
+	if(labels.some(label=> {
+		let maybePrefix = label.slice(0,prefix.length)
+		let maybeSuffix = suffix.length===0 ? "" : label.slice(0-suffix.length)
+		return maybePrefix === prefix && maybeSuffix === suffix
+		})){
+		return true
+		}
+	return `Hoist identifiers by labeling some dimension/group with \`${prefix}...${suffix}\``
+}

--- a/rules/h1.js
+++ b/rules/h1.js
@@ -25,7 +25,7 @@ function ruleFn(match, path, project, options={}) {
 		return {level:"verbose",description:"Field hoisting not relevant for 0-PK views"}
 	}
 	const labels = dimensions
-		.filter(dim => !dim.hidden && !dim.required_access_grants)
+		.filter(f => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
 		.map(dim => dim.group_label || dim.label || defaultLabelForField(dim))
 		// Dimension_groups being for dates, they don't really work as identifiers.
 		// Omitting them for now, but may revisit the decision in the future

--- a/rules/h1.js
+++ b/rules/h1.js
@@ -17,26 +17,26 @@ module.exports = function(
 };
 
 function ruleFn(match, path, project, options={}) {
-	const prefix = options.prefix!==undefined ? options.prefix : "["
-	const suffix = options.suffix!==undefined ? options.suffix : "]"
+	const prefix = options.prefix!==undefined ? options.prefix : '[';
+	const suffix = options.suffix!==undefined ? options.suffix : ']';
 	const view = match;
-	const dimensions = Object.values(view?.dimension || {})
-	if(dimensions.some(d => d.$name.match(/^pk0_/))){
-		return {level:"verbose",description:"Field hoisting not relevant for 0-PK views"}
+	const dimensions = Object.values(view?.dimension || {});
+	if (dimensions.some((d) => d.$name.match(/^pk0_/))) {
+		return {level: 'verbose', description: 'Field hoisting not relevant for 0-PK views'};
 	}
 	const labels = dimensions
-		.filter(f => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
-		.map(dim => dim.group_label || dim.label || defaultLabelForField(dim))
+		.filter((f) => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
+		.map((dim) => dim.group_label || dim.label || defaultLabelForField(dim));
 		// Dimension_groups being for dates, they don't really work as identifiers.
 		// Omitting them for now, but may revisit the decision in the future
-		//.concat(Object.values(view?.dimension_group || {}).map(dg => dg.label))
+		// .concat(Object.values(view?.dimension_group || {}).map(dg => dg.label))
 
-	if(labels.some(label=> {
-		let maybePrefix = label.slice(0,prefix.length)
-		let maybeSuffix = suffix.length===0 ? "" : label.slice(0-suffix.length)
-		return maybePrefix === prefix && maybeSuffix === suffix
-		})){
-		return true
-		}
-	return `Hoist identifiers by labeling some dimension/group with \`${prefix}...${suffix}\``
+	if (labels.some((label)=> {
+		let maybePrefix = label.slice(0, prefix.length);
+		let maybeSuffix = suffix.length===0 ? '' : label.slice(0-suffix.length);
+		return maybePrefix === prefix && maybeSuffix === suffix;
+	})) {
+		return true;
+	}
+	return `Hoist identifiers by labeling some dimension/group with \`${prefix}...${suffix}\``;
 }

--- a/rules/h2.js
+++ b/rules/h2.js
@@ -23,7 +23,7 @@ function ruleFn(match, path, project, options={}) {
 		const fields = []
 			.concat(Object.values(view[section] || {}))
 			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
-			.filter(f => !f.hidden)
+			.filter(f => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
 			// Should we also filter out fields that are re-labeled into other view_labels, even though it's against rule F2?
 
 		const hasGroupLabels = fields.some(f=>f.group_label)

--- a/rules/h2.js
+++ b/rules/h2.js
@@ -23,8 +23,9 @@ function ruleFn(match, path, project, options={}) {
 		const fields = []
 			.concat(Object.values(view[section] || {}))
 			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
-			.filter(f => !f.hidden && !f.required_access_grants)
-	
+			.filter(f => !f.hidden)
+			// Should we also filter out fields that are re-labeled into other view_labels, even though it's against rule F2?
+
 		const hasGroupLabels = fields.some(f=>f.group_label)
 
 		if(fields.length > threshold && !hasGroupLabels){

--- a/rules/h2.js
+++ b/rules/h2.js
@@ -1,0 +1,37 @@
+const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
+
+module.exports = function(
+	project,
+) {
+	let ruleDef = {
+		$name: 'H2',
+		match: `$.model.*.view.*`,
+		ruleFn,
+	};
+	let messages = checkCustomRule(ruleDef, project, {ruleSource: 'internal'});
+
+	return {messages};
+};
+
+function ruleFn(match, path, project, options={}) {
+	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 20;
+	const view = match;
+
+	const messages = []
+	const sections = ['dimension', 'measure']
+	for(let section of sections){
+		const fields = []
+			.concat(Object.values(view[section] || {}))
+			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
+			.filter(f => !f.hidden && !f.required_access_grants)
+	
+		const hasGroupLabels = fields.some(f=>f.group_label)
+
+		if(fields.length > threshold && !hasGroupLabels){
+			messages.push(`View has ${fields.length} visible ${section}s (above ${threshold}). Use group_label to organize fields.`)
+		}
+	}
+
+	if(messages.length){return messages}
+	return true
+}

--- a/rules/h2.js
+++ b/rules/h2.js
@@ -17,22 +17,24 @@ function ruleFn(match, path, project, options={}) {
 	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 20;
 	const view = match;
 
-	const messages = []
-	const sections = ['dimension', 'measure']
-	for(let section of sections){
+	const messages = [];
+	const sections = ['dimension', 'measure'];
+	for (let section of sections) {
 		const fields = []
 			.concat(Object.values(view[section] || {}))
-			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
-			.filter(f => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
+			.concat(Object.values(section==='dimension' && view['dimension_group'] || {}))
+			.filter((f) => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants);
 			// Should we also filter out fields that are re-labeled into other view_labels, even though it's against rule F2?
 
-		const hasGroupLabels = fields.some(f=>f.group_label)
+		const hasGroupLabels = fields.some((f)=>f.group_label);
 
-		if(fields.length > threshold && !hasGroupLabels){
-			messages.push(`View has ${fields.length} visible ${section}s (above ${threshold}). Use group_label to organize fields.`)
+		if (fields.length > threshold && !hasGroupLabels) {
+			messages.push(`View has ${fields.length} visible ${section}s (above ${threshold}). Use group_label to organize fields.`);
 		}
 	}
 
-	if(messages.length){return messages}
-	return true
+	if (messages.length) {
+		return messages;
+	}
+	return true;
 }

--- a/rules/h3.js
+++ b/rules/h3.js
@@ -1,5 +1,5 @@
 const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
-const defaultLabelForField = require('./rules-lib/default-label-for-field.js')
+const defaultLabelForField = require('./rules-lib/default-label-for-field.js');
 
 module.exports = function(
 	project,
@@ -16,44 +16,50 @@ module.exports = function(
 
 function ruleFn(match, path, project, options={}) {
 	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 10;
-	const delimiter = options.delimiter || " > "
+	const delimiter = options.delimiter || ' > ';
 	const view = match;
 
-	const messages = []
-	const sections = ['dimension', 'measure']
-	for(let section of sections){
+	const messages = [];
+	const sections = ['dimension', 'measure'];
+	for (let section of sections) {
 		const fields = []
 			.concat(Object.values(view[section] || {}))
-			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
-			.filter(f => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
+			.concat(Object.values(section==='dimension' && view['dimension_group'] || {}))
+			.filter((f) => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants);
 			// Should we also filter out fields that are re-labeled into other view_labels, even though it's against rule F2?
 
 		const groupLabels = fields
-			.map(f => f.group_label || f.$type === "dimension_group" && defaultLabelForField(f))
+			.map((f) => f.group_label || f.$type === 'dimension_group' && defaultLabelForField(f))
 			.filter(Boolean)
-			.filter(unique)
+			.filter(unique);
 
-		if(groupLabels.length <= threshold){continue}
-
-		const hasGroupSortLabels = groupLabels.some(label => label.includes(delimiter))
-
-		if(!hasGroupSortLabels){
-			messages.push(`View has ${groupLabels.length} visible ${section} groups (above ${threshold}). Sort groups into categories with a "${delimiter}" delimiter.`)
-			continue
+		if (groupLabels.length <= threshold) {
+			continue;
 		}
-		
-		const superGroupedLabels = groupLabels
-			.map(label => label.split(delimiter)[0])
-			.filter(unique)
 
-		if(superGroupedLabels.length === groupLabels.length){
-			messages.push(`Some group labels contain the sorting delimiter ("${delimiter}"), but no groups share the same prefix, so no reduction in user complexity is achieved.`)
-			continue
+		const hasGroupSortLabels = groupLabels.some((label) => label.includes(delimiter));
+
+		if (!hasGroupSortLabels) {
+			messages.push(`View has ${groupLabels.length} visible ${section} groups (above ${threshold}). Sort groups into categories with a "${delimiter}" delimiter.`);
+			continue;
+		}
+
+		const superGroupedLabels = groupLabels
+			.map((label) => label.split(delimiter)[0])
+			.filter(unique);
+
+		if (superGroupedLabels.length === groupLabels.length) {
+			messages.push(`Some group labels contain the sorting delimiter ("${delimiter}"), but no groups share the same prefix, so no reduction in user complexity is achieved.`);
+			continue;
 		}
 	}
 
-	if(messages.length){return messages}
-	return true
+	if (messages.length) {
+		return messages;
+	}
+	return true;
 }
 
-function unique(x,i,arr){return arr.indexOf(x)===i}
+function unique(x, i, arr) {
+	return arr.indexOf(x)===i;
+}

--- a/rules/h3.js
+++ b/rules/h3.js
@@ -15,7 +15,7 @@ module.exports = function(
 };
 
 function ruleFn(match, path, project, options={}) {
-	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 8;
+	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 10;
 	const delimiter = options.delimiter || " > "
 	const view = match;
 

--- a/rules/h3.js
+++ b/rules/h3.js
@@ -1,0 +1,58 @@
+const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
+const defaultLabelForField = require('./rules-lib/default-label-for-field.js')
+
+module.exports = function(
+	project,
+) {
+	let ruleDef = {
+		$name: 'H3',
+		match: `$.model.*.view.*`,
+		ruleFn,
+	};
+	let messages = checkCustomRule(ruleDef, project, {ruleSource: 'internal'});
+
+	return {messages};
+};
+
+function ruleFn(match, path, project, options={}) {
+	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 8;
+	const delimiter = options.delimiter || " > "
+	const view = match;
+
+	const messages = []
+	const sections = ['dimension', 'measure']
+	for(let section of sections){
+		const fields = []
+			.concat(Object.values(view[section] || {}))
+			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
+			.filter(f => !f.hidden && !f.required_access_grants)
+
+		const groupLabels = fields
+			.map(f => f.group_label || f.$type === "dimension_group" && defaultLabelForField(f))
+			.filter(Boolean)
+			.filter(unique)
+
+		if(groupLabels.length <= threshold){continue}
+
+		const hasGroupSortLabels = groupLabels.some(label => label.includes(delimiter))
+
+		if(!hasGroupSortLabels){
+			messages.push(`View has ${groupLabels.length} visible ${section} groups (above ${threshold}). Sort groups into categories with a "${delimiter}" delimiter.`)
+			continue
+		}
+		
+		const superGroupedLabels = groupLabels
+			.map(label => label.split(delimiter)[0])
+			.filter(unique)
+
+		if(superGroupedLabels.length === groupLabels.length){
+			messages.push(`Some group labels contain the sorting delimiter ("${delimiter}"), but no groups share the same prefix, so no reduction in user complexity is achieved.`)
+			continue
+		}
+	}
+
+	if(messages.length){return messages}
+	return true
+}
+
+function unique(x,i,arr){return arr.indexOf(x)===i}

--- a/rules/h3.js
+++ b/rules/h3.js
@@ -25,7 +25,8 @@ function ruleFn(match, path, project, options={}) {
 		const fields = []
 			.concat(Object.values(view[section] || {}))
 			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
-			.filter(f => !f.hidden && !f.required_access_grants)
+			.filter(f => !f.hidden)
+			// Should we also filter out fields that are re-labeled into other view_labels, even though it's against rule F2?
 
 		const groupLabels = fields
 			.map(f => f.group_label || f.$type === "dimension_group" && defaultLabelForField(f))

--- a/rules/h3.js
+++ b/rules/h3.js
@@ -25,7 +25,7 @@ function ruleFn(match, path, project, options={}) {
 		const fields = []
 			.concat(Object.values(view[section] || {}))
 			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
-			.filter(f => !f.hidden)
+			.filter(f => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
 			// Should we also filter out fields that are re-labeled into other view_labels, even though it's against rule F2?
 
 		const groupLabels = fields

--- a/rules/h4.js
+++ b/rules/h4.js
@@ -1,0 +1,47 @@
+const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
+const defaultLabelForField = require('./rules-lib/default-label-for-field.js')
+
+module.exports = function(
+	project,
+) {
+	let ruleDef = {
+		$name: 'H4',
+		match: `$.model.*.view.*`,
+		ruleFn,
+	};
+	let messages = checkCustomRule(ruleDef, project, {ruleSource: 'internal'});
+
+	return {messages};
+};
+
+function ruleFn(match, path, project, options={}) {
+	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 30;
+	const delimiter = options.delimiter || " > "
+	const view = match;
+
+	const messages = []
+	const sections = ['dimension', 'measure']
+	for(let section of sections){
+		const fields = []
+			.concat(Object.values(view[section] || {}))
+			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
+			.filter(f => !f.hidden && !f.required_access_grants)
+
+		const topLabels = fields
+			.map((field,f) =>
+				field.group_label?.split(delimiter)[0]
+				|| field.$type === "dimension_group" && defaultLabelForField(field).split(delimiter)[0]
+				|| field.$name + "####" + f
+				)
+			.filter(unique)
+
+		if(topLabels.length <= threshold){continue}
+
+		messages.push(`View has ${topLabels.length} visible top-level ${section} labels (above ${threshold}). Move fields into groups (or move groups into sorting groups using "${delimiter}").`)
+	}
+
+	if(messages.length){return messages}
+	return true
+}
+
+function unique(x,i,arr){return arr.indexOf(x)===i}

--- a/rules/h4.js
+++ b/rules/h4.js
@@ -1,5 +1,5 @@
 const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
-const defaultLabelForField = require('./rules-lib/default-label-for-field.js')
+const defaultLabelForField = require('./rules-lib/default-label-for-field.js');
 
 module.exports = function(
 	project,
@@ -16,32 +16,38 @@ module.exports = function(
 
 function ruleFn(match, path, project, options={}) {
 	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 30;
-	const delimiter = options.delimiter || " > "
+	const delimiter = options.delimiter || ' > ';
 	const view = match;
 
-	const messages = []
-	const sections = ['dimension', 'measure']
-	for(let section of sections){
+	const messages = [];
+	const sections = ['dimension', 'measure'];
+	for (let section of sections) {
 		const fields = []
 			.concat(Object.values(view[section] || {}))
-			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
-			.filter(f => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
+			.concat(Object.values(section==='dimension' && view['dimension_group'] || {}))
+			.filter((f) => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants);
 
 		const topLabels = fields
-			.map((field,f) =>
+			.map((field, f) =>
 				field.group_label?.split(delimiter)[0]
-				|| field.$type === "dimension_group" && defaultLabelForField(field).split(delimiter)[0]
-				|| field.$name + "####" + f
-				)
-			.filter(unique)
+				|| field.$type === 'dimension_group' && defaultLabelForField(field).split(delimiter)[0]
+				|| field.$name + '####' + f,
+			)
+			.filter(unique);
 
-		if(topLabels.length <= threshold){continue}
+		if (topLabels.length <= threshold) {
+			continue;
+		}
 
-		messages.push(`View has ${topLabels.length} visible top-level ${section} labels (above ${threshold}). Move fields into groups (or move groups into sorting groups using "${delimiter}").`)
+		messages.push(`View has ${topLabels.length} visible top-level ${section} labels (above ${threshold}). Move fields into groups (or move groups into sorting groups using "${delimiter}").`);
 	}
 
-	if(messages.length){return messages}
-	return true
+	if (messages.length) {
+		return messages;
+	}
+	return true;
 }
 
-function unique(x,i,arr){return arr.indexOf(x)===i}
+function unique(x, i, arr) {
+	return arr.indexOf(x)===i;
+}

--- a/rules/h4.js
+++ b/rules/h4.js
@@ -25,7 +25,7 @@ function ruleFn(match, path, project, options={}) {
 		const fields = []
 			.concat(Object.values(view[section] || {}))
 			.concat(Object.values(section==="dimension" && view["dimension_group"] || {}))
-			.filter(f => !f.hidden && !f.required_access_grants)
+			.filter(f => !(f.hidden ?? view.fields_hidden_by_default) && !f.required_access_grants)
 
 		const topLabels = fields
 			.map((field,f) =>

--- a/rules/h5.js
+++ b/rules/h5.js
@@ -15,23 +15,25 @@ module.exports = function(
 };
 
 function ruleFn(match, path, project, options={}) {
-	const prefix = options.prefix!==undefined ? options.prefix : "["
-	const suffix = options.suffix!==undefined ? options.suffix : "]"
-	const enforceHidden = options.enforceHidden!==undefined ? options.enforceHidden : false
+	const prefix = options.prefix!==undefined ? options.prefix : '[';
+	const suffix = options.suffix!==undefined ? options.suffix : ']';
+	const enforceHidden = options.enforceHidden!==undefined ? options.enforceHidden : false;
 	const explore = match;
 
-	if(!explore.join){
-		return true
+	if (!explore.join) {
+		return true;
 	}
 
-	if(explore.hidden && !enforceHidden){
-		return true
+	if (explore.hidden && !enforceHidden) {
+		return true;
 	}
 
-	const maybePrefix = explore.view_label?.slice(0,prefix.length)
-	const maybeSuffix = suffix.length===0 ? "" : explore.view_label?.slice(0-suffix.length)
+	const maybePrefix = explore.view_label?.slice(0, prefix.length);
+	const maybeSuffix = suffix.length===0 ? '' : explore.view_label?.slice(0-suffix.length);
 
-	if(maybePrefix === prefix && maybeSuffix === suffix){return true}
-	
-	return `Hoist view in explore by using view_label like \`${prefix}...${suffix}\``
+	if (maybePrefix === prefix && maybeSuffix === suffix) {
+		return true;
+	}
+
+	return `Hoist view in explore by using view_label like \`${prefix}...${suffix}\``;
 }

--- a/rules/h5.js
+++ b/rules/h5.js
@@ -1,0 +1,37 @@
+const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
+
+module.exports = function(
+	project,
+) {
+	let ruleDef = {
+		$name: 'H5',
+		match: `$.model.*.explore.*`,
+
+		ruleFn,
+	};
+	let messages = checkCustomRule(ruleDef, project, {ruleSource: 'internal'});
+
+	return {messages};
+};
+
+function ruleFn(match, path, project, options={}) {
+	const prefix = options.prefix!==undefined ? options.prefix : "["
+	const suffix = options.suffix!==undefined ? options.suffix : "]"
+	const enforceHidden = options.enforceHidden!==undefined ? options.enforceHidden : false
+	const explore = match;
+
+	if(!explore.join){
+		return true
+	}
+
+	if(explore.hidden && !enforceHidden){
+		return true
+	}
+
+	const maybePrefix = explore.view_label?.slice(0,prefix.length)
+	const maybeSuffix = suffix.length===0 ? "" : explore.view_label?.slice(0-suffix.length)
+
+	if(maybePrefix === prefix && maybeSuffix === suffix){return true}
+	
+	return `Hoist view in explore by using view_label like \`${prefix}...${suffix}\``
+}

--- a/rules/h6.js
+++ b/rules/h6.js
@@ -1,5 +1,5 @@
 const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
-const defaultLabelForField = require('./rules-lib/default-label-for-field.js')
+const defaultLabelForField = require('./rules-lib/default-label-for-field.js');
 
 module.exports = function(
 	project,
@@ -16,39 +16,41 @@ module.exports = function(
 
 function ruleFn(match, path, project, options={}) {
 	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 20;
-	const delimiter = options.delimiter || " > "
+	const delimiter = options.delimiter || ' > ';
 	const explore = match;
-	const model = project.model[path[1]]
+	const model = project.model[path[1]];
 
-	const joins = Object.values(explore.join || {})
+	const joins = Object.values(explore.join || {});
 
 	const viewLabels = [explore, ...joins]
-		.map(join => 
+		.map((join) =>
 			join.view_label
 			// If no join.view_label, next is label on the associated view
 			|| model?.view?.[join.from || join.$name]?.label
 			// If neither, fallback is based on join name
 			|| defaultLabelForField(join))
 		.filter(Boolean)
-		.filter(unique)
-		
-	if(viewLabels.length <= threshold){
+		.filter(unique);
+
+	if (viewLabels.length <= threshold) {
 		return true;
 	}
 
-	const hasSortLabels = viewLabels.some(label => label.includes(delimiter))
-	if(!hasSortLabels){
+	const hasSortLabels = viewLabels.some((label) => label.includes(delimiter));
+	if (!hasSortLabels) {
 		return `Explore has ${viewLabels.length} visible view labels (above ${threshold}). Sort views into categories with a "${delimiter}" delimiter.`;
 	}
-	
+
 	const topLabels = viewLabels
-		.map(l => l.split(delimiter)[0])
+		.map((l) => l.split(delimiter)[0])
 		.filter(Boolean)
-		.filter(unique)
-	if(topLabels.length == viewLabels.length){
-		return `Some view labels contain the sorting delimiter ("${delimiter}"), but no groups share the same prefix, so no reduction in user complexity is achieved.`
+		.filter(unique);
+	if (topLabels.length == viewLabels.length) {
+		return `Some view labels contain the sorting delimiter ("${delimiter}"), but no groups share the same prefix, so no reduction in user complexity is achieved.`;
 	}
 	return true;
 }
 
-function unique(x,i,arr){return arr.indexOf(x)===i}
+function unique(x, i, arr) {
+	return arr.indexOf(x)===i;
+}

--- a/rules/h6.js
+++ b/rules/h6.js
@@ -1,0 +1,54 @@
+const checkCustomRule = require('../lib/custom-rule/custom-rule.js');
+const defaultLabelForField = require('./rules-lib/default-label-for-field.js')
+
+module.exports = function(
+	project,
+) {
+	let ruleDef = {
+		$name: 'H6',
+		match: `$.model.*.explore.*`,
+		ruleFn,
+	};
+	let messages = checkCustomRule(ruleDef, project, {ruleSource: 'internal'});
+
+	return {messages};
+};
+
+function ruleFn(match, path, project, options={}) {
+	const threshold = !isNaN(options.threshold) ? parseInt(options.threshold) : 20;
+	const delimiter = options.delimiter || " > "
+	const explore = match;
+	const model = project.model[path[1]]
+
+	const joins = Object.values(explore.join || {})
+
+	const viewLabels = [explore, ...joins]
+		.map(join => 
+			join.view_label
+			// If no join.view_label, next is label on the associated view
+			|| model?.view?.[join.from || join.$name]?.label
+			// If neither, fallback is based on join name
+			|| defaultLabelForField(join))
+		.filter(Boolean)
+		.filter(unique)
+		
+	if(viewLabels.length <= threshold){
+		return true;
+	}
+
+	const hasSortLabels = viewLabels.some(label => label.includes(delimiter))
+	if(!hasSortLabels){
+		return `Explore has ${viewLabels.length} visible view labels (above ${threshold}). Sort views into categories with a "${delimiter}" delimiter.`;
+	}
+	
+	const topLabels = viewLabels
+		.map(l => l.split(delimiter)[0])
+		.filter(Boolean)
+		.filter(unique)
+	if(topLabels.length == viewLabels.length){
+		return `Some view labels contain the sorting delimiter ("${delimiter}"), but no groups share the same prefix, so no reduction in user complexity is achieved.`
+	}
+	return true;
+}
+
+function unique(x,i,arr){return arr.indexOf(x)===i}

--- a/rules/k1.js
+++ b/rules/k1.js
@@ -32,7 +32,7 @@ function ruleFn(match, path, project) {
 	let pkDimensions = (Object.values(view.dimension || {})).filter(pkNamingConvention);
 
 	if (!pkDimensions.length) {
-		return `View ${view.$name} has no dimensions that follow the PK naming convetion`;
+		return `View ${view.$name} has no dimensions that follow the PK naming convention`;
 	}
 
 	let declaredNs = pkDimensions

--- a/rules/rules-lib/default-label-for-field.js
+++ b/rules/rules-lib/default-label-for-field.js
@@ -1,0 +1,9 @@
+module.exports = function defaultLabelForField(field){
+	//Maybe add logic based on yesno type?
+	const labelFromName = field.$name
+		.split("_")
+		.filter(Boolean)
+		.map(word => word.slice(0,1).toUpperCase() + word.slice(1))
+		.join(" ")
+	return labelFromName
+}


### PR DESCRIPTION
- Add "Hierarchy" rules: H1, H2, H3, H4, H5, H6. These rules provide suggested labeling patterns to increase organization at various levels from the field to the explore.
- Fix file inclusion when an imported project includes a file using a "project root" (single `/` ) path (issue 214)
- Fix typos in output strings (manifest loader, rule K1) (issue 195)
- Allow custom rules to accept `options`
- Added information about parser errors to the Style Guide